### PR TITLE
Fix title for Schedule Intelligent Data Management Framework purge and analysis tasks (AX 2012)

### DIFF
--- a/articles/dev-itpro/lifecycle-services/ax-2012/schedule-purge-analysis-tasks.md
+++ b/articles/dev-itpro/lifecycle-services/ax-2012/schedule-purge-analysis-tasks.md
@@ -1,7 +1,7 @@
 ---
 # required metadata
 
-title: Troubleshoot your Dynamics AX 2012 R3 deployment on Azure
+title: Schedule Intelligent Data Management Framework purge and analysis tasks (AX 2012)
 description: This topic describes the options on the Microsoft Dynamics AX Intelligent Data Management Framework(IDMF) Schedule menu, and how to use them.
 author: kfend
 manager: AnnBe
@@ -30,7 +30,7 @@ ms.dyn365.ops.version: 2012
 
 ---
 
-# Troubleshoot your Dynamics AX 2012 R3 deployment on Azure
+# Schedule Intelligent Data Management Framework purge and analysis tasks (AX 2012)
 
 [!include[banner](../../includes/banner.md)]
 


### PR DESCRIPTION
The title for this article is "Troubleshoot your Dynamics AX 2012 R3 deployment on Azure" which has nothing to do with the content.

The content is actually about Intelligent Data Management framework purge tasks (as can be seen in the navigation linking to the page which says: "Schedule purge and analysis tasks"

Change title to "Schedule Intelligent Data Management Framework purge and analysis tasks (AX 2012)" which is in line with the rest of the pages in this chapter.