### PR TITLE
Update to drop stored procs used by DMF

### DIFF
--- a/articles/dev-itpro/database/copy-database-from-sql-server-to-azure-sql.md
+++ b/articles/dev-itpro/database/copy-database-from-sql-server-to-azure-sql.md
@@ -132,6 +132,8 @@ set value = 1
 where name = 'TEMPTABLEINAXDB'
 
 drop procedure XU_DisableEnableNonClusteredIndexes
+drop procedure if exists SP_ConfigureTablesForChangeTracking
+drop procedure if exists SP_ConfigureTablesForChangeTracking_V2
 drop schema [NT AUTHORITY\NETWORK SERVICE]
 drop user [NT AUTHORITY\NETWORK SERVICE]
 drop user axdbadmin


### PR DESCRIPTION
Updated script to drop these two SQL stored procedures (SP) - SP_ConfigureTablesForChangeTracking & SP_ConfigureTablesForChangeTracking_V2 (version existing in DB will depend on AX 7 version) 
These reference the database name and if migrated to Azure SQL will contain the incorrect name. The SP is dynamically created if  missing through class/method - AifChangeTrackingConfiguration::checkStoredProcExists, so can be safely deleted.

# Thanks for contributing

Please describe the changes that you recommend that we make, and why. If you have any issues with formatting, please see the CONTRIBUTING file, or just submit the change, and we'll be happy to help. The content publishing team for Microsoft Dynamics 365 for Finance and Operations team will review your pull request, and be in touch. 
