### PR TITLE
Update to drop stored procs used by DMF

### DIFF
--- a/articles/dev-itpro/database/copy-database-from-azure-sql-to-sql-server.md
+++ b/articles/dev-itpro/database/copy-database-from-azure-sql-to-sql-server.md
@@ -274,6 +274,9 @@ WHERE T1.storageproviderid = 1 --Azure storage
 
 ALTER DATABASE [<your AX database name>] SET CHANGE_TRACKING = ON (CHANGE_RETENTION = 6 DAYS, AUTO_CLEANUP = ON)
 GO
+DROP PROCEDURE IF EXISTS SP_ConfigureTablesForChangeTracking
+DROP PROCEDURE IF EXISTS SP_ConfigureTablesForChangeTracking_V2
+GO
 -- Begin Refresh Retail FullText Catalogs
 DECLARE @RFTXNAME NVARCHAR(MAX);
 DECLARE @RFTXSQL NVARCHAR(MAX);


### PR DESCRIPTION
Updated script to drop these two SQL stored procedures (SP) - SP_ConfigureTablesForChangeTracking & SP_ConfigureTablesForChangeTracking_V2 (version existing in DB will depend on AX 7 version) 
These reference the database name and if migrated to Azure SQL will contain the incorrect name. The SP is dynamically created if  missing through class/method - AifChangeTrackingConfiguration::checkStoredProcExists, so can be safely deleted.

# Thanks for contributing

Please describe the changes that you recommend that we make, and why. If you have any issues with formatting, please see the CONTRIBUTING file, or just submit the change, and we'll be happy to help. The content publishing team for Microsoft Dynamics 365 for Finance and Operations team will review your pull request, and be in touch. 
