### PR TITLE
Update prerequisites-standard-costs.md

### DIFF
--- a/articles/supply-chain/cost-management/prerequisites-standard-costs.md
+++ b/articles/supply-chain/cost-management/prerequisites-standard-costs.md
@@ -54,7 +54,7 @@ Before you define the item posting rules, use the **Transaction combinations** p
 
 **4. Define inventory parameters that are related to standard costs.** 
 
--  Use the **Bills of materials** tab on the **Inventory parameters** page to define two cost control parameters that are related to standard costs. 
+-  Use the **Inventory accounting** tab on the **Inventory accounting policies setup > Parameters** page to define two cost control parameters that are related to standard costs.
 
     -  In the **Cost breakdown** field, select **None** or **Sub ledger**. If you select **Sub ledger**, the cost breakdown is an *active* cost breakdown. An active cost breakdown is critical for calculating, retaining, and viewing cost group segmentation across a multilevel product structure for standard cost items. When the cost breakdown is active, you can report and analyze inventory, work in process (WIP), and cost of goods sold (COGS) per cost group in a single-level, multilevel, or total format. When the cost breakdown is active, if you activate a manufactured item's cost, the cost group segmentation will be stored in the item's cost record. 
 


### PR DESCRIPTION
The Inventory parameters page was changed to the Inventory accounting policies setup > Parameters page as the Cost breakdown and Variances to standard fields are not available on the Bill of materials tab.