### PR TITLE
Adjust based on issue #213

### DIFF
--- a/articles/dev-itpro/user-interface/create-deep-links.md
+++ b/articles/dev-itpro/user-interface/create-deep-links.md
@@ -39,11 +39,11 @@ Learn how to create shareable, secured URLs to forms and records.
 Overview
 --------
 
-The URL Generator enables developers to create shareable and secured URLs (a.k.a. deep links) to specific forms. An optional data context can be passed to the form to display filtered or specific data when the form is opened. The URL Generator enables scenarios such as embedding links in reports, emails, and external applications, enabling users to quickly and easily locate the specified forms or data by simply navigating using the generated link.
+The URL Generator enables developers to create shareable and secured URLs (a.k.a. deep links) to specific forms that are root navigable. An optional data context can be passed to the form to display filtered or specific data when the form is opened. The URL Generator enables scenarios such as embedding links in reports, emails, and external applications, enabling users to quickly and easily locate the specified forms or data by simply navigating using the generated link.
 
 ### Purpose
 
--   Empower developers to generate URLs that can be used to navigate to forms in a specified instance.
+-   Empower developers to generate URLs that can be used to navigate to root navigable forms in a specified instance.
 -   Empower developers to optionally specify a data context that should be displayed when navigating to the specified form.
 -   Empower users to share, save, and access the generated URLs from any browser with Internet access.
 -   Secure the URLs to prevent unauthorized access to the system, forms, or data.
@@ -55,8 +55,7 @@ The URL Generator enables developers to create shareable and secured URLs (a.k.a
 Access to the domain/client is controlled through the existing login and SSL mechanism.
 
 ### Form access
-
-Access to the form is controlled through the specified Menu Item, and the accompanying Menu Item security system. If a user navigates using a URL which contains a Menu Item that the user does not have access to, then the Menu Item security will prevent the form from opening. The user will receive message which says that they do not have the necessary permissions to open the form.
+Access to forms is controlled through Menu Items, as Menu Items are the entry points where security is enforced. If a user navigates using a URL that contains a Menu Item the user does not have access to, then the Menu Item security will prevent the form from opening. The user will receive a message indicating they do not have the necessary permissions to open the form. Note also that deep links will only work for Menu Items that allow root navigation. 
 
 ### Data access
 


### PR DESCRIPTION
Updated article to reflect that deep links only work for root navigable menu items.  Also would like copy editing to confirm that "Menu Item" should be capitalized in this article.