### PR TITLE
Update task-recorder.md

### DIFF
--- a/articles/dev-itpro/user-interface/task-recorder.md
+++ b/articles/dev-itpro/user-interface/task-recorder.md
@@ -389,7 +389,7 @@ Using a **pre-release** Chrome extension, Task recorder is able to take screensh
 
 6.  Restart Chrome.
 
-Task recorder will now take screenshots of the tab that has the client running. These screenshots are only available for a certain period of time after the recording has been played. Starting in Platform Update 16, screenshots are available for a week after playback. Prior to that, the screenshots are only available for 10 minutes. If the screenshots have expired, you can regenerate them by playing the task recording again.  
+Task recorder will now take screenshots of the tab that has the client running. These screenshots are only available for a certain period of time after the recording has been played. Starting in Platform Update 16, screenshots are available for a week after playback. Prior to that, the screenshots are only available for 15 minutes. If the screenshots have expired, you can regenerate them by playing the task recording again.  
 
 Note that Task recorder **does not** capture screenshots from other tabs or of the user's desktop.
 

--- a/articles/dev-itpro/user-interface/task-recorder.md
+++ b/articles/dev-itpro/user-interface/task-recorder.md
@@ -1,8 +1,8 @@
 ---
 # required metadata
 
-title: Task Recorder
-description: This topic describes how to use Task Recorder to record client functions.
+title: Task recorder
+description: This topic describes how to use Task recorder to record client functions.
 author: jasongre
 manager: AnnBe
 ms.date: 10/24/2017
@@ -30,34 +30,34 @@ ms.search.validFrom: 2016-02-28
 ms.dyn365.ops.version: AX 7.0.0
 ---
 
-# Task Recorder
+# Task recorder
 
 [!include [banner](../includes/banner.md)]
 
-This topic describes how to use Task Recorder to record client functions.
+This topic describes how to use Task recorder to record client functions.
 
 ## Overview
 
-### The new Task Recorder
+### The new Task recorder
 
-In Microsoft Dynamics 365 for Finance and Operations, Task Recorder has been re-built from the ground up with a focus on high-responsiveness, a flexible extensibility API, and seamless integrations with consumers of business process recordings. We're carrying forward Task Recorder integration with the Lifecycle Services BPM tool (<https://bpm.lcs.dynamics.com>), so that users can continue to produce rich business process diagrams from recordings for analyzing and designing their applications. We're also introducing the ability for Task Recorder to auto-generate application verification tests from business process recordings, as well as playback previously recorded processes. These new features also come with new gestures that allow users to take full advantage of the powerful new Task Recorder. If you're reading this tutorial for the first time and wish to practice the topics as they're discussed, note that Arabic and Roman numerals indicate actionable steps that you should take. Alphabetical entries are used to indicate paragraphs with helpful details about using Task Recorder.
+In Microsoft Dynamics 365 for Finance and Operations, Task recorder has been re-built from the ground up with a focus on high-responsiveness, a flexible extensibility API, and seamless integrations with consumers of business process recordings. We're carrying forward Task recorder integration with the Lifecycle Services BPM tool (<https://bpm.lcs.dynamics.com>), so that users can continue to produce rich business process diagrams from recordings for analyzing and designing their applications. We're also introducing the ability for Task recorder to auto-generate application verification tests from business process recordings, as well as playback previously recorded processes. These new features also come with new gestures that allow users to take full advantage of the powerful new Task recorder. If you're reading this tutorial for the first time and wish to practice the topics as they're discussed, note that Arabic and Roman numerals indicate actionable steps that you should take. Alphabetical entries are used to indicate paragraphs with helpful details about using Task recorder.
 
 ### Architecture
 
-Task Recorder is able to record user actions in the client with exact fidelity. This is achieved by instrumenting each control to notify Task Recorder about the execution of a user action. The control notifies Task Recorder that an event has occurred and passes along all pertinent information about the corresponding user action in real-time. From this information, Task Recorder is able to capture the type of user action (such as a button click, value entry, navigation, etc.) and any data related to the user action (such as input data value and type, form context, record context, etc.). Task Recorder persists the information with enough detail to ensure that a playback of the recording can execute the recorded actions exactly as they were executed by the user.
+Task recorder is able to record user actions in the client with exact fidelity. This is achieved by instrumenting each control to notify Task recorder about the execution of a user action. The control notifies Task recorder that an event has occurred and passes along all pertinent information about the corresponding user action in real-time. From this information, Task recorder is able to capture the type of user action (such as a button click, value entry, navigation, etc.) and any data related to the user action (such as input data value and type, form context, record context, etc.). Task recorder persists the information with enough detail to ensure that a playback of the recording can execute the recorded actions exactly as they were executed by the user.
 
 ### Basic configuration
 
-Task Recorder is pre-installed and users are able to begin recording business processes immediately after opening the client for the first time. Task Recorder supports Microsoft Edge, Internet Explorer 11, and the latest version of Google Chrome.
+Task recorder is pre-installed and users are able to begin recording business processes immediately after opening the client for the first time. Task recorder supports Microsoft Edge, Internet Explorer 11, and the latest version of Google Chrome.
 
 > [!IMPORTANT]
-> The **Task guides** tab is currently not available in Microsoft Dynamics 365 for Talent and Microsoft Dynamics 365 for Retail. We are currently working to enable this functionality in a future release. The Task guides in the Getting Started experience in Talent remain available to cover basic functionality. Procedural help is also available on the docs.microsoft.com site ([docs.microsoft.com/dynamics365/unified-operations](../../index.md)) for both Retail and Talent.
+> The **Task guides** tab is currently not available in Microsoft Dynamics 365 for Talent and Microsoft Dynamics 365 for Retail. We are currently working to enable this functionality in a future release. Task guides in the Getting Started experience in Talent remain available to cover basic functionality. Procedural help is also available on the docs.microsoft.com site ([docs.microsoft.com/dynamics365/unified-operations](../../index.md)) for both Retail and Talent.
 
 ## Create a recording
-The following steps show the process for creating a new recording using Task Recorder.
+The following steps show the process for creating a new recording using Task recorder.
 
-1.  Open the client and log in. It's a good practice to refresh the browser before each new recording. This creates a new user session and restarts Task Recorder, providing the most stable recording experience.
-2.  Select the company that you want to use while recording. If this is your first time using Task Recorder, you can follow along as this tutorial creates a sample recording based on a Fleet Management business process. You will need to load the Fleet demo data to follow along:
+1.  Open the client and log in. It's a good practice to refresh the browser before each new recording. This creates a new user session and restarts Task recorder, providing the most stable recording experience.
+2.  Select the company that you want to use while recording. If this is your first time using Task recorder, you can follow along as this tutorial creates a sample recording based on a Fleet Management business process. You will need to load the Fleet demo data to follow along:
     1.  Go to **Dashboard &gt; Fleet Management &gt; Fleet setup**.
     2.  Click **Load demo data**.
     3.  When the data is finished loading, click **Close**.
@@ -66,7 +66,7 @@ The following steps show the process for creating a new recording using Task Rec
 3.  Go to **Settings &gt; Task recorder**.
     ![This image shows the location of the Task recorder menu button, which is used to open Task recorder.](./media/taskrecorderguide-taskrecordermenubutton.png)
     
-4.  The **Task Recorder Pane** opens. The user may click the "**X**" in the upper-right corner to close the **Task Recorder Pane** before beginning a new recording. The pane can be reopened by following the previous steps.
+4.  The **Task recorder pane** opens. The user may click the "**X**" in the upper-right corner to close the **Task recorder pane** before beginning a new recording. The pane can be reopened by following the previous steps.
     [![This image shows the Task recorder main menu.](./media/taskrecorderguide-taskrecordermainmenu.png)](./media/taskrecorderguide-taskrecordermainmenu.png)
     
 5.  Click **Create a new recording**.
@@ -77,27 +77,27 @@ The following steps show the process for creating a new recording using Task Rec
     
     [![This image shows the Task recorder toolbar button which allows opening the Task recorder pane while recording.](./media/taskrecorderguide-taskrecordertoolbarclose.png)](./media/taskrecorderguide-taskrecordertoolbarclose.png)
 
-7.  The **Task Recorder** enters **Recording Mode.** The pane now shows information and controls related to the process of recording. For more information about how to use the buttons shown, see the [section on using the recording controls](#recording-controls).
+7.  The **Task recorder** enters **Recording Mode.** The pane now shows information and controls related to the process of recording. For more information about how to use the buttons shown, see the [section on using the recording controls](#recording-controls).
 [![This image shows what the Task recorder toolbar and Task recorder pane look like during recording.](./media/taskrecorderguide-taskrecorderrecordingmode.png)](./media/taskrecorderguide-taskrecorderrecordingmode.png)
 
-Now you're ready to record a business process using Task Recorder. If you're following this guide as a first-time user, you may complete the following Fleet Management scenario as an example. Otherwise, you can record your own application scenario.
+Now you're ready to record a business process using Task recorder. If you're following this guide as a first-time user, you may complete the following Fleet Management scenario as an example. Otherwise, you can record your own application scenario.
 
 ## Record a Fleet Management scenario
-1.  In the **Task Recorder Pane**, click **Start task**.
+1.  In the **Task recorder pane**, click **Start task**.
 2.  Set **Name** to "Create a new rental customer". Leave the **Comment** field blank.
 3.  Click **OK**. 
 [![This image shows the menu used to start a task while recording.](./media/taskrecorderguide-taskrecorderaddingatask.png)](./media/taskrecorderguide-taskrecorderaddingatask.png)
 4.  The task is added to the **Steps list**. 
-**[![This image shows the Steps List after a Task has been added.](./media/taskrecorderguide-taskrecordertaskadded.png)](./media/taskrecorderguide-taskrecordertaskadded.png)**
+**[![This image shows the Steps List after a task has been added.](./media/taskrecorderguide-taskrecordertaskadded.png)](./media/taskrecorderguide-taskrecordertaskadded.png)**
 5.  Go to **Dashboard &gt; Fleet Management &gt; Reservation Management**.
 6.  Go to **All customers** under the **Summary** tab.
 7.  In the Action Pane, click **New**.
 8.  Enter a first and last name for the customer.
 9.  Click **Save**.
-10. In the **Task Recorder Pane**, click **End task**. 
+10. In the **Task recorder pane**, click **End task**. 
 **[![This image shows what the Steps List looks like after recording a few steps.](./media/taskrecorderguide-taskrecordertaskended.png)](./media/taskrecorderguide-taskrecordertaskended.png)**
 11. Return to the **Reservation Management** workspace by clicking the browser back button twice.
-12. In the **Task Recorder Pane**, click **Start task**. Name the task "Rent a vehicle to the new customer." Click **Start**.
+12. In the **Task recorder pane**, click **Start task**. Name the task "Rent a vehicle to the new customer." Click **Start**.
 13. Click (**+**) **Rental** under **Summary**.
 14. Under **Information**, select a "1975 Litware McKinley" as the vehicle.
 15. Under **Information**, set the customer to the one just created.
@@ -106,10 +106,10 @@ Now you're ready to record a business process using Task Recorder. If you're fol
 18. In the Action Pane, click **Start Rental**.
 19. Set the return date to some date in the future.
 20. Click **OK**.
-21. In the **Task Recorder Pane**, click **End task**.
-22. In the **Task Recorder Pane**, click **Stop**.
+21. In the **Task recorder pane**, click **End task**.
+22. In the **Task recorder pane**, click **Stop**.
 
-Congratulations! You have created your first Task recording. You can proceed to [download the recording, or publish it to LCS](#download-options).
+Congratulations! You have created your first task recording. You can proceed to [download the recording, or publish it to LCS](#download-options).
 
 ## Recording controls
 ### Stop
@@ -119,13 +119,13 @@ Congratulations! You have created your first Task recording. You can proceed to 
 
 ### Start/End task
 
-**Start/End task** enables a user to specify the beginning and ending of a set of grouped steps. Click the **Start Task** button to add a "Start Task" step to the end of the current list of recorded steps. Then perform the steps that you want to include in the task. After you've performed (and thus recorded) the steps in the task, click the **End Task** button to add an "End Task" step to the end of the current list of recorded steps.
+**Start/End task** enables a user to specify the beginning and ending of a set of grouped steps. Click the **Start task** button to add a "Start task" step to the end of the current list of recorded steps. Then perform the steps that you want to include in the task. After you've performed (and thus recorded) the steps in the task, click the **End task** button to add an "End task" step to the end of the current list of recorded steps.
 
-**Note**: You must start your tasks before performing/recording the steps that you want to include in the task. You must End the task after you have performed/recorded all of the steps that you want to include in the task.
+**Note**: You must start your tasks before performing/recording the steps that you want to include in the task. You must end the task after you have performed/recorded all of the steps that you want to include in the task.
 
-**Tasks** are purely an organization tool, and consumers of business process recording can interpret the Task groupings in useful ways. Tasks can be nested within other Tasks, providing the flexibility to organize very long and complex business processes. 
+**Tasks** are purely an organization tool, and consumers of business process recording can interpret the task groupings in useful ways. Tasks can be nested within other tasks, providing the flexibility to organize very long and complex business processes. 
 
-[![This image shows the location of the Start and End Task buttons, which are used to create Task groupings around sets of recorded steps.](./media/taskrecorderguide-taskrecorderrecordingcontrolstasks.png)](./media/taskrecorderguide-taskrecorderrecordingcontrolstasks.png)
+[![This image shows the location of the Start and End task buttons, which are used to create task groupings around sets of recorded steps.](./media/taskrecorderguide-taskrecorderrecordingcontrolstasks.png)](./media/taskrecorderguide-taskrecorderrecordingcontrolstasks.png)
 
 
 ### Delete/Restore step
@@ -140,14 +140,14 @@ Congratulations! You have created your first Task recording. You can proceed to 
 
 ### Add validation
 
-**Add validation** enables a developer to add a placeholder step to the end of the current list of recorded steps. This placeholder step does not appear when viewing the Task guide, and this placeholder step is not executed when maintaining a recording. The placeholder step is only used by the X++ code generator which allows creating an X++ test from a Task recording. When generating the X++ test, the code generator will automatically add a method stub to the generated code, which the developer can add X++ code into. The code generator will also call this method, and thus execute the developers code, when the generated test is run. The method will be called according to the order in which it was added to the recording.
+**Add validation** enables a developer to add a placeholder step to the end of the current list of recorded steps. This placeholder step does not appear when viewing the task guide, and this placeholder step is not executed when maintaining a recording. The placeholder step is only used by the X++ code generator which allows creating an X++ test from a task recording. When generating the X++ test, the code generator will automatically add a method stub to the generated code, which the developer can add X++ code into. The code generator will also call this method, and thus execute the developers code, when the generated test is run. The method will be called according to the order in which it was added to the recording.
 
 ## Adding annotations
-An **annotation** is any additional information that is associated with a step in a Task recording. Annotations contain information that is in addition to the information that is automatically recorded by Task Recorder.
+An **annotation** is any additional information that is associated with a step in a task recording. Annotations contain information that is in addition to the information that is automatically recorded by Task recorder.
 
 ### Step instruction
 
-The **Step instruction** is the primary text that is displayed for this step in the Task guide. There are usually 2-3 alternative options for step instructions, and they appear in the following order when editing the annotation.
+The **Step instruction** is the primary text that is displayed for this step in the task guide. There are usually 2-3 alternative options for step instructions, and they appear in the following order when editing the annotation.
 
 [![This image shows the annotation options for changing the Step instruction](./media/taskrecorderguide-annotationlabels.png)](./media/taskrecorderguide-annotationlabels.png) 
 
@@ -155,7 +155,7 @@ This image shows the annotation options for changing a step.
 - **Preferred value instruction*** This type of instruction will direct the user to enter the same data that was used when the step was recorded. *Example*: In the First name field, enter 'John'.
 - **Example value label** This type of instruction will direct the user to enter their own data, indicating that the data that was used when the step was recorded was only *Example* data. *Example*: In the First name field, enter a value.
 
-  If the user clicks the **See more** button when on this step of the Task guide, they will be able to see the data that was used when the step was recorded. This recorded data value will be labeled as an *Example* data value. 
+  If the user clicks the **See more** button when on this step of the task guide, they will be able to see the data that was used when the step was recorded. This recorded data value will be labeled as an *Example* data value. 
    > [!NOTE]
    > Steps that are not related to fields, such as clicking buttons, opening forms, or selecting records from a lookup, do not set *Example value label* as an option when annotating.
    
@@ -169,27 +169,27 @@ This image shows the annotation options for changing a step.
 
 ### Titles and notes
 
-Titles and notes provide places for user-specified text to be associated with a step in a Task guide.
--   **Title** The **Title** lets you specify the text that appears above the **Step Instruction** for this step in the Task guide. The **Title** is a good place to put text that you want the user to read before the complete the action that is indicated by the **Step Instruction**.
--   **Note** You can use a **Note** to specify text that appears in the expandable section of the pop-up for this step in the Task guide. The note is a good place to put optional reading material or other information that may be useful to the user, but is not required for them to read in order to complete the action that is indicated by the **Step Instruction**.
+Titles and notes provide places for user-specified text to be associated with a step in a task guide.
+-   **Title** The **Title** lets you specify the text that appears above the **Step Instruction** for this step in the task guide. The **Title** is a good place to put text that you want the user to read before the complete the action that is indicated by the **Step Instruction**.
+-   **Note** You can use a **Note** to specify text that appears in the expandable section of the pop-up for this step in the task guide. The note is a good place to put optional reading material or other information that may be useful to the user, but is not required for them to read in order to complete the action that is indicated by the **Step Instruction**.
 
-## Hide from Task guide
+## Hide from task guide
 
-The **Hide** option allows the author to prevent certain steps from appearing in the Task guide. This is useful for hiding steps which are necessary for the Task recording to execute in Maintenance mode but should not be seen by the end-user. An example of such steps are copy steps, system-generated steps, and data clean-up steps. Hiding a task will result in all of the steps that are recorded within that task to also be hidden.
+The **Hide** option allows the author to prevent certain steps from appearing in the task guide. This is useful for hiding steps which are necessary for the task recording to execute in Maintenance mode but should not be seen by the end-user. An example of such steps are copy steps, system-generated steps, and data clean-up steps. Hiding a task will result in all of the steps that are recorded within that task to also be hidden.
 
 ## Recording gestures
 
-The basic recording capability allows a user to record an end-to-end business process using Task Recorder without adding overhead to the process. In some circumstances, more advanced recording features can be leveraged to create even richer business process recordings. Each of the following gestures are triggered by right-clicking on a control in the client that supports the gesture. Each gesture results in a step being added to the list of steps for the recording. If the gesture is not supported for a particular control, then the gesture will not appear in the right-click menu.
+The basic recording capability allows a user to record an end-to-end business process using Task recorder without adding overhead to the process. In some circumstances, more advanced recording features can be leveraged to create even richer business process recordings. Each of the following gestures are triggered by right-clicking on a control in the client that supports the gesture. Each gesture results in a step being added to the list of steps for the recording. If the gesture is not supported for a particular control, then the gesture will not appear in the right-click menu.
 
 ### Copy
 
-This right-click gesture allows copying a control to the Task Recorder “clipboard”. The control may then be used later as part of a **Paste** or **Validate** gesture.
+This right-click gesture allows copying a control to the Task recorder “clipboard”. The control may then be used later as part of a **Paste** or **Validate** gesture.
 
 ### Paste
 
-This right-click gesture allows the pasting a value from a previously copied control. The Task Recorder paste function operates just like the paste function that users may be familiar with, and it has an additional benefit when used during recordings. During playback of a recording, Task Recorder will also re-play the **Copy** and **Paste** commands that were recorded. During playback, if the copied control has a different value than it had during recording, then Task Recorder will use the current value when pasting, rather than use the value the copied control had during recording. This is useful in scenarios were the copied control has a value that can change between environments (such as recIDs, number sequences, etc.).
+This right-click gesture allows the pasting a value from a previously copied control. The Task recorder paste function operates just like the paste function that users may be familiar with, and it has an additional benefit when used during recordings. During playback of a recording, Task recorder will also re-play the **Copy** and **Paste** commands that were recorded. During playback, if the copied control has a different value than it had during recording, then Task recorder will use the current value when pasting, rather than use the value the copied control had during recording. This is useful in scenarios were the copied control has a value that can change between environments (such as recIDs, number sequences, etc.).
 
-There’s an additional benefit from using **Copy** and **Paste** when generating test code. For any control whose value is set via the **Paste** action, Task Recorder does not need to create a parameterized input variable for that control’s value, because it is set based on another control’s value. This can be very useful in scenarios where an entity is created, such as a Customer, and an identifier for the Customer is frequently entered during the recording. Instead of needing to manually re-enter the Customer name or ID throughout the scenario, and causing Task Recorder to generate a parameterized input variable for each entry, the user can instead repeatedly **Paste** the Customer name/ID after copying it once and Task Recorder will generate a single parameterized input variable to represent the Customer name/ID. This feature can make changing the input data for a generated test much easier.
+There’s an additional benefit from using **Copy** and **Paste** when generating test code. For any control whose value is set via the **Paste** action, Task recorder does not need to create a parameterized input variable for that control’s value, because it is set based on another control’s value. This can be very useful in scenarios where an entity is created, such as a Customer, and an identifier for the Customer is frequently entered during the recording. Instead of needing to manually re-enter the Customer name or ID throughout the scenario, and causing Task recorder to generate a parameterized input variable for each entry, the user can instead repeatedly **Paste** the Customer name/ID after copying it once and Task recorder will generate a single parameterized input variable to represent the Customer name/ID. This feature can make changing the input data for a generated test much easier.
 
 ###  Validate
 
@@ -200,20 +200,20 @@ This right-click gesture allows the user to insert a step that validates the val
 
 ### Add info step
 
-This right-click gesture allows the user to insert a step and supply their own text for the step. This feature is primarily useful for creating Task guides. An **Informational Step** is a Task guide step where the instruction text for the step are user-specified. **Info steps** are useful for describing actions that are a part of the scenario but must take place outside of the client, such as searching for an item inventory or checking an email for information.
+This right-click gesture allows the user to insert a step and supply their own text for the step. This feature is primarily useful for creating task guides. An **Informational Step** is a task guide step where the instruction text for the step are user-specified. **Info steps** are useful for describing actions that are a part of the scenario but must take place outside of the client, such as searching for an item inventory or checking an email for information.
 
-The user can specify where an **Info step** should appear in the Task guide. The **Info step** can either point to a control on a form, if the step is associated with the control, or the **Info step** can appear in the upper-right of the form, if the step is external to the client and the step is an explanation that applies to the entire form.
+The user can specify where an **Info step** should appear in the task guide. The **Info step** can either point to a control on a form, if the step is associated with the control, or the **Info step** can appear in the upper-right of the form, if the step is external to the client and the step is an explanation that applies to the entire form.
 
 > [!NOTE]
-> Because **Info steps** are manually specified steps, and are not automatically recorded by Task Recorder when the user takes an action on a control, the **Info step** does not have the capability to automatically progress when a user completes the step in the Task guide. Because the **Info step** is not associated with taking an action in the client, there is no action for the Task guide to detect that the user has completed in order to automatically progress to the next step.
+> Because **Info steps** are manually specified steps and are not automatically recorded by Task recorder when the user takes an action on a control, the **Info step** does not have the capability to automatically progress when a user completes the step in the task guide. Because the **Info step** is not associated with taking an action in the client, there is no action for a task guide to detect that the user has completed in order to automatically progress to the next step.
 
 ## Download options
-After clicking **Stop**, several options are shown for downloading files related to the completed recording. Click **Download recording**, and save the Task recording package to your desktop. We'll use this file later.
+After clicking **Stop**, several options are shown for downloading files related to the completed recording. Click **Download recording**, and save the task recording package to your desktop. We'll use this file later.
 [![This image shows the optoins provided to download or save a recording after recoring as ended.](./media/taskrecorderguide-taskrecorderdownloadoptions.png)](./media/taskrecorderguide-taskrecorderdownloadoptions.png)
 
-### Download the Task recording package
+### Download the task recording package
 
-You should download the Task recording package after you finish your recording. The Task recording package can be used to play a Task guide, maintain the recording, or edit the recording's annotations.
+You should download the task recording package after you finish your recording. The task recording package can be used to play a task guide, maintain the recording, or edit the recording's annotations.
 
 ### Download the raw recording file
 
@@ -225,20 +225,20 @@ The Microsoft Word document for your recording contains the recorded steps as we
 
 ### Save the recording to an LCS library
 
-Saving your recording to an LCS library will publish the BPM diagram for the recording on the specified business process. If the selected LCS library is set as a Help library, then you will be able to find the Task guide for this recording by searching the Help menu.
+Saving your recording to an LCS library will publish the BPM diagram for the recording on the specified business process. If the selected LCS library is set as a Help library, then you will be able to find the task guide for this recording by searching the Help menu.
 
 ## Maintain a recording
-The **Maintain** functionality of Task Recorder can automatically execute the steps of an existing recording, using the forms and values that were originally recorded. The Maintenance mode can be used to update an existing recording after making a change to the underlying application that alters the business process steps that are required for the scenario. It's important to remember that Task Recorder is simultaneously re-recording the steps and playing them back when in Maintenance mode. When Maintenance is complete a new recording is produced, which contains any steps from the existing recorded that were executed, as well as any new steps which were manually performed by the user. Any steps that are not executed, whether by the user or automatically by Task recorder, are not included in this new recording. When in Maintenance mode, additional controls are added to the Task Recorder Pane. To maintain an existing recording:
+The **Maintain** functionality of Task recorder can automatically execute the steps of an existing recording, using the forms and values that were originally recorded. The Maintenance mode can be used to update an existing recording after making a change to the underlying application that alters the business process steps that are required for the scenario. It's important to remember that Task recorder is simultaneously re-recording the steps and playing them back when in Maintenance mode. When Maintenance is complete a new recording is produced, which contains any steps from the existing recorded that were executed, as well as any new steps which were manually performed by the user. Any steps that are not executed, whether by the user or automatically by Task recorder, are not included in this new recording. When in Maintenance mode, additional controls are added to the Task recorder Pane. To maintain an existing recording:
 1. Refresh the browser tab. 
     > [!NOTE]
     > It is a good practice to refresh the browser before each new recording. Remember that Maintenance mode also creates a new recording.
     
-2. Open the **Task Recorder Pane**.
+2. Open the **Task recorder pane**.
 3. Click **Maintain a recording**.
-4. Click **It is in a file I can upload** to load a recording from a previously downloaded Task Recorder package (.axtr).
+4. Click **It is in a file I can upload** to load a recording from a previously downloaded Task recorder package (.axtr).
    -   If you're reading this guide for the first time and following along, choose the “Create a new rental reservation” file that you downloaded previously.
 
-5. Click **Start** and Task Recorder begins recording in Maintenance mode.
+5. Click **Start** and Task recorder begins recording in Maintenance mode.
 
 ## Maintenance controls
 ### Step
@@ -247,7 +247,7 @@ The **Maintain** functionality of Task Recorder can automatically execute the st
 
 ### Play
 
-**Play** will begin sequential execution of the remaining steps in the recording, until Playback is paused, or all steps have been executed. While playing, the **Play** button will become a **Pause** button that can be used to pause playback. This pause button is not to be confused with the pause button under the **Recording** section which controls whether actions are being recorded. The state of recording is independent from the state of playback, and the respective pause buttons function independently of each other. If playback is unable to successfully execute a step for any reason, such as not being able to find a button that has been renamed, Task Recorder will skip that step and playback will automatically pause. This provides the user an opportunity to replace the obsolete step by completing the new steps in the client. Task Recorder will record the new steps and ignore the step that was skipped. The user can then click **Play** to continue playback for the remaining steps. Once the recording is complete, the user can download the updated recording which will contain all of the steps of the original recording, omitting any skipped steps, and including any new steps.
+**Play** will begin sequential execution of the remaining steps in the recording, until Playback is paused, or all steps have been executed. While playing, the **Play** button will become a **Pause** button that can be used to pause playback. This pause button is not to be confused with the pause button under the **Recording** section which controls whether actions are being recorded. The state of recording is independent from the state of playback, and the respective pause buttons function independently of each other. If playback is unable to successfully execute a step for any reason, such as not being able to find a button that has been renamed, Task recorder will skip that step and playback will automatically pause. This provides the user an opportunity to replace the obsolete step by completing the new steps in the client. Task recorder will record the new steps and ignore the step that was skipped. The user can then click **Play** to continue playback for the remaining steps. Once the recording is complete, the user can download the updated recording which will contain all of the steps of the original recording, omitting any skipped steps, and including any new steps.
 
 To **Skip** a step or *remove* a step from a recording, play back until the step that you want to skip, click **Pause the Recording**, **Step** over the step you want to skip, **Continue Recording** and then **Continue Playback**. Because recording was paused while the step was executed, the step will not be included in the new recording.
 
@@ -308,73 +308,73 @@ You can expand and collapse the **Recording name** and **Recording description**
 
 ### Advanced grid row selection
 
-In order for Task Recorder to reliably select the correct grid rows during test playback, it needs the user to explicitly define filtering criteria that produce only the intended records. Task Recorder can’t reliably use mechanisms like the grid row index or recID, as these can vary between environments and between test executions. While recording, after opening a form that contains a grid and selecting a record in the grid, the **Task Recorder Grid Row Selection Dialog** will appear. The dialog will look similar to the filter pane, and will be pre-populated with Task Recorder's "best guess" as to which filter criteria uniquely identify the row that you have selected. After verifying Task Recorder's "best guess", press **Apply** to have Task Recorder remember the filter criteria and select the specified row in the grid. There are some cases in which Task Recorder will fail to find filter criteria that uniquely identifies the row you've clicked. When these situations occur, the list of filters will be empty when the dialog appears. The user can manually define filters that uniquely identify the row, or the user can choose to have row selection recorded based on the row’s index in the grid.
+In order for Task recorder to reliably select the correct grid rows during test playback, it needs the user to explicitly define filtering criteria that produce only the intended records. Task recorder can’t reliably use mechanisms like the grid row index or recID, as these can vary between environments and between test executions. While recording, after opening a form that contains a grid and selecting a record in the grid, the **Task recorder grid row selection dialog** will appear. The dialog will look similar to the filter pane, and will be pre-populated with Task recorder's "best guess" as to which filter criteria uniquely identify the row that you have selected. After verifying Task recorder's "best guess", press **Apply** to have Task recorder remember the filter criteria and select the specified row in the grid. There are some cases in which Task recorder will fail to find filter criteria that uniquely identifies the row you've clicked. When these situations occur, the list of filters will be empty when the dialog appears. The user can manually define filters that uniquely identify the row, or the user can choose to have row selection recorded based on the row’s index in the grid.
 
 ### Rollback changes to business data
 
-The **Rollback changes to business data** option will revert any business data that is created during recording when the recording is completed. This option is primarily for enabling developer scenarios related to creating Task recordings to be used as tests. The **Rollback** mechanism will only rollback records that are created during the recording session. It will not rollback changes made to existing recordings, nor will it rollback deletions made to existing records. In addition, because of security concerns the **Rollback** mechanism is only available for use on non-production systems where the Test tools, including the Test models, have been installed.
+The **Rollback changes to business data** option will revert any business data that is created during recording when the recording is completed. This option is primarily for enabling developer scenarios related to creating task recordings to be used as tests. The **Rollback** mechanism will only rollback records that are created during the recording session. It will not rollback changes made to existing recordings, nor will it rollback deletions made to existing records. In addition, because of security concerns the **Rollback** mechanism is only available for use on non-production systems where the Test tools, including the Test models, have been installed.
 
-### Playing a Task guide
+### Playing a task guide
 
-A Task guide is an end-user focused experience that allows the user to follow a guided step-by-step set of instructions for how to complete a business scenario that is contained in a Task recording. The user is instructed to complete each step by way of a pop-up prompt, which will animate across the form and point to the UI element that the user should interact with, and also inform the user about how to interact with the element, such as by saying "Click here" or "In this field, enter data". Each step that the user is instructed to complete is based on the step that was originally recorded in the Task recording file that the Task guide is based off of. Since the Task recording file contains the data that describes the step that was originally recorded, the Task guide is able to automatically detect when the user has completed the step as expected. When the Task guide recognizes that the user has completed the step, the Task guide automatically progresses to the next step. 
+A task guide is an end-user focused experience that allows the user to follow a guided step-by-step set of instructions for how to complete a business scenario that is contained in a task recording. The user is instructed to complete each step by way of a pop-up prompt, which will animate across the form and point to the UI element that the user should interact with, and also inform the user about how to interact with the element, such as by saying "Click here" or "In this field, enter data". Each step that the user is instructed to complete is based on the step that was originally recorded in the task recording file that the task guide is based on. Since the task recording file contains the data that describes the step that was originally recorded, the task guide is able to automatically detect when the user has completed the step as expected. When the task guide recognizes that the user has completed the step, the task guide automatically progresses to the next step. 
 
 > [!NOTE]
-> One of the ways the Task guide recognizes that a user has completed a step is by detecting when the value in a field has changed. While the Task guide does not require that specific values be set, it does require that the field value is changed in order to detect that the step was completed. In order to detect that the field value was changed, the user much first change the value and then press the Tab key or click in an area outside of the UI element. Only after pressing Tab or clicking outside of the UI element does the client recognize that the field value has been changed, and proceed to run any necessary application validation or business logic. The Task guide relies on the client to recognize that the field value has been changed before it can detect that the step was completed by the user.
+> One of the ways the task guide recognizes that a user has completed a step is by detecting when the value in a field has changed. While the task guide does not require that specific values be set, it does require that the field value is changed in order to detect that the step was completed. In order to detect that the field value was changed, the user much first change the value and then press the Tab key or click in an area outside of the UI element. Only after pressing Tab or clicking outside of the UI element does the client recognize that the field value has been changed, and proceed to run any necessary application validation or business logic. The task guide relies on the client to recognize that the field value has been changed before it can detect that the step was completed by the user.
 
-### What can a Task guide allow a user to do?
+### What can a task guide allow a user to do?
 
-When a user is completing a Task guide, the client behaves in the same manner, with the same data, security, and validation rules as it does when the user is not completing a Task guide. There is no difference of behavior in the client that would allow a user to take an action that they cannot otherwise take when they are not completing a Task guide. When a user is completing a Task guide:
--   Any data the user enters is subject to the same data validation rules as when not playing the Task guide.
--   Any data the user enters may be saved, and the user may modify data according to the same restrictions and rules as when not playing the Task guide.
--   Any security mechanisms the user encounters behave the same as when the user is not playing the Task guide.
--   Any forms or controls the user accesses are subject to the same security and access mechanisms as when the user is not playing the Task guide.
+When a user is completing a task guide, the client behaves in the same manner, with the same data, security, and validation rules as it does when the user is not completing a task guide. There is no difference of behavior in the client that would allow a user to take an action that they cannot otherwise take when they are not completing a task guide. When a user is completing a task guide:
+-   Any data the user enters is subject to the same data validation rules as when not playing the task guide.
+-   Any data the user enters may be saved, and the user may modify data according to the same restrictions and rules as when not playing the task guide.
+-   Any security mechanisms the user encounters behave the same as when the user is not playing the task guide.
+-   Any forms or controls the user accesses are subject to the same security and access mechanisms as when the user is not playing the task guide.
 
-### The "On-rails" feature of Task guide
+### The "On-rails" feature of task guides
 
-By default, when a user begins a Task guide, they are placed "on-rails". These "rails" prevent the user from *clicking* on elements other than the element the Task guide is pointing to. When the user tries to click on something outside of the UI element that the Task guide is pointing to, the Task guide pop-up will animate to let the user know that they cannot progress until they complete the current step of the Task guide. While a user is prohibited from *clicking* on other elements, the user is not prevented from tabbing through the other controls on the form, and the user is not prevented from using keyboard shortcuts. This is by design, as the "on-rails" feature is designed for and targeted at first-time users, who are expected to primarily use the mouse as they become familiar with the application. More advanced/experienced users are able to turn off the "on-rails" feature when they complete a Task guide. At any time during the Task guide, the "rails" can be taken off by clicking the "Unlock" button that appears in the Task recorder toolbar at the top of the page. You can also use this button to restore the "rails" at any point during the Task guide. The "on-rails" feature may be turned off automatically by the Task guide under certain circumstances. When the rails are off, the user is able to click on UI elements in the same manner as when the Task guide is not running. The "on-rails" feature may be turned off automatically in the following cases:
+By default, when a user begins a task guide, they are placed "on-rails". These "rails" prevent the user from *clicking* on elements other than the element the task guide is pointing to. When the user tries to click on something outside of the UI element that the task guide is pointing to, the task guide pop-up will animate to let the user know that they cannot progress until they complete the current step of the task guide. While a user is prohibited from *clicking* on other elements, the user is not prevented from tabbing through the other controls on the form, and the user is not prevented from using keyboard shortcuts. This is by design, as the "on-rails" feature is designed for and targeted at first-time users, who are expected to primarily use the mouse as they become familiar with the application. More advanced/experienced users are able to turn off the "on-rails" feature when they complete a task guide. At any time during the task guide, the "rails" can be taken off by clicking the "Unlock" button that appears in the Task recorder toolbar at the top of the page. You can also use this button to restore the "rails" at any point during the task guide. The "on-rails" feature may be turned off automatically by the task guide under certain circumstances. When the rails are off, the user is able to click on UI elements in the same manner as when the task guide is not running. The "on-rails" feature may be turned off automatically in the following cases:
 -   The user is being directed to navigate to form using the Navigation Menu or the Search bar
-    -   Because the user is free to use either entry point, the Task guide does not point to a specific entry point, and does not prevent the user from use either entry point.
--   The Task guide enters an Error state (see below for a list of error states).
--   The Task guide is displaying an Informational Step.
+    -   Because the user is free to use either entry point, the task guide does not point to a specific entry point, and does not prevent the user from use either entry point.
+-   The task guide enters an Error state (see below for a list of error states).
+-   The task guide is displaying an Informational Step.
 
 ### Error detection
 
-An *error state* occurs when the Task guide is not able to point to the UI element that is associated with the current step because the UI element is not visible on the screen. When the Task guide detects that the current step requires the user to interact with a UI element that is not visible, then the Task guide pop-up will move to the upper-right side of the screen. These causes of an error state can be simplified into two categories.
+An *error state* occurs when the task guide is not able to point to the UI element that is associated with the current step because the UI element is not visible on the screen. When the task guide detects that the current step requires the user to interact with a UI element that is not visible, then the task guide pop-up will move to the upper-right side of the screen. These causes of an error state can be simplified into two categories.
 
 #### The control is not visible on the form
 
 *This error state usually occurs when the user has opened or closed  the incorrect tab page, FastTab, collapsible section, FactBox, or pop-out menu.*
 
-Because the UI element that is needed for the current step is somewhere on the current form, but it is not visible on the screen, the Task guide pop-up will simply move to the upper-right side of the screen while displaying the same instruction that informs the user of the action they need to take.
+Because the UI element that is needed for the current step is somewhere on the current form, but it is not visible on the screen, the task guide pop-up will simply move to the upper-right side of the screen while displaying the same instruction that informs the user of the action they need to take.
 
-Because the Task guide cannot locate the UI element on the screen, the user will need to manually identify what is hiding from the UI element. After the user has made the UI element visible on the screen, the Task guide pop-up will automatically recognize that the element is visible, and it will re-locate so that it is again pointing at the now-visible UI element.
+Because the task guide cannot locate the UI element on the screen, the user will need to manually identify what is hiding from the UI element. After the user has made the UI element visible on the screen, the task guide pop-up will automatically recognize that the element is visible, and it will re-locate so that it is again pointing at the now-visible UI element.
 
 #### The control is not on the form
 
 *This error state usually occurs when the user has gone to the wrong form, either by navigating to the wrong form, or by leaving the correct form.*
 
-Because the UI element is not visible on the screen, the Task guide pop-up will move to the upper-right side of the screen. In addition, when the Task guide detects that the user is on the wrong from, the Task guide pop-up text will change to inform the user of the form they should navigate to.
+Because the UI element is not visible on the screen, the task guide pop-up will move to the upper-right side of the screen. In addition, when the task guide detects that the user is on the wrong from, the task guide pop-up text will change to inform the user of the form they should navigate to.
 
-In some cases, the Task guide pop-up will not mention the form by name. This is because the user may need to navigate to a dynamic form. A dynamic form is a form that is not modeled, frequently known as a runtime-generated form. These sorts of forms do not have a proper name. Some examples of runtime-generated forms include simple and custom lookups. The way for a user to navigate to a lookup form is to re-open the lookup.
+In some cases, the task guide pop-up will not mention the form by name. This is because the user may need to navigate to a dynamic form. A dynamic form is a form that is not modeled, frequently known as a runtime-generated form. These sorts of forms do not have a proper name. Some examples of runtime-generated forms include simple and custom lookups. The way for a user to navigate to a lookup form is to re-open the lookup.
 
 ### Next & previous step
 
-These buttons appear on the Task guide pop-up and allow a user to manually control the flow of the Task guide. When clicking the Next or Previous step, the Task guide will move to the next or previous step in the guide. The Task guide does not check whether the user has completed a step before going to the next or previous step. The Task guide also ***never*** automatically completes any step for the user, even when using the Next and Previous Step options. Using the Next and Previous step buttons can result in producing an error state, if the previous or next step refers to a UI element that is on the current form. When the user is completing an Informational Step, the only way to proceed is to use the Next step button. This is required because an Informational Step does not represent an action that was recorded on any UI element. Since no action was recorded in the Task recording, the Task guide does not have the information necessary to know what action to expect the user to complete.
+These buttons appear on the task guide pop-up and allow a user to manually control the flow of the task guide. When clicking the Next or Previous step, the task guide will move to the next or previous step in the guide. The task guide does not check whether the user has completed a step before going to the next or previous step. The task guide also ***never*** automatically completes any step for the user, even when using the Next and Previous Step options. Using the Next and Previous step buttons can result in producing an error state, if the previous or next step refers to a UI element that is on the current form. When the user is completing an Informational Step, the only way to proceed is to use the Next step button. This is required because an Informational Step does not represent an action that was recorded on any UI element. Since no action was recorded in the task recording, the task guide does not have the information necessary to know what action to expect the user to complete.
 
 ### The "See more" button
 
-Clicking this button will expand the Task guide pop-up to show additional information related to the step. The additional information is often optional reading material that is not required for the user to successfully complete the step. In the additional information, the user may see:
+Clicking this button will expand the task guide pop-up to show additional information related to the step. The additional information is often optional reading material that is not required for the user to successfully complete the step. In the additional information, the user may see:
 -   An **Example** value
-    -   The Example value is the value that was originally used when the Task recording was created.
+    -   The Example value is the value that was originally used when the task recording was created.
     -   Example values only appear for steps that use non-lookup fields. This includes text fields, number fields, date fields combo boxes, and check boxes.
 -   A **Note**
-    -   A Note may contain scenario-specific information that will help provide context to the user about the current step of the Task guide.
+    -   A Note may contain scenario-specific information that will help provide context to the user about the current step of the task guide.
 
 ## Screenshot extension setup 
 
 ### Document generation setup (optional)
 
-Using a **pre-release** Chrome extension, Task Recorder is able to take screenshots of the browser as a user records a business process. After the user completes the recording, Task Recorder can then use these screenshots to generate Microsoft Word documents. To enable this functionality, follow the steps below to install the pre-release Google Chrome extension that enables Task Recorder to capture screenshots during recording.
+Using a **pre-release** Chrome extension, Task recorder is able to take screenshots of the browser as a user records a business process. After the user completes the recording, Task recorder can then use these screenshots to generate Microsoft Word documents. To enable this functionality, follow the steps below to install the pre-release Google Chrome extension that enables Task recorder to capture screenshots during recording.
 
 1.  Open Google Chrome
 2.  Go to **Menu &gt; More tools &gt; Extensions**. 
@@ -383,27 +383,27 @@ Using a **pre-release** Chrome extension, Task Recorder is able to take screensh
 
 3.  Select the **Developer mode** box.
 4.  Click **Load unpacked extension**.
-5.  Browse to the folder containing the Task Recorder extension, select the folder, and click **OK**. The extension is loaded. Ensure that the **Enabled** box is selected to turn the extension on. With a locally hosted developer machine, the extension should be located at &lt;local disk&gt;FMLabTaskRecorderScreenshot. Otherwise, you can download the FMLab folder which contains the extension from GitHub at<https://github.com/Microsoft/FMLab>.
+5.  Browse to the folder containing the Task recorder extension, select the folder, and click **OK**. The extension is loaded. Ensure that the **Enabled** box is selected to turn the extension on. With a locally hosted developer machine, the extension should be located at &lt;local disk&gt;FMLabTaskRecorderScreenshot. Otherwise, you can download the FMLab folder which contains the extension from GitHub at<https://github.com/Microsoft/FMLab>.
 
     [![This image shows what the Extensions settings page looks like once the screenshot extension has been loaded.](./media/taskrecorderguide-googlechromeextensionsmenu1.png)](./media/taskrecorderguide-googlechromeextensionsmenu1.png)
 
 6.  Restart Chrome.
 
-Task Recorder will now take screenshots of the tab that has the client running. These screenshots are only available for a certain period of time after the recording has been played. Starting in Platform Update 16, screenshots are available for a week after playback. Prior to that, the screenshots are only available for 10 minutes. If the screenshots have expired, you can regenerate them by playing the task recording again.  
+Task recorder will now take screenshots of the tab that has the client running. These screenshots are only available for a certain period of time after the recording has been played. Starting in Platform Update 16, screenshots are available for a week after playback. Prior to that, the screenshots are only available for 10 minutes. If the screenshots have expired, you can regenerate them by playing the task recording again.  
 
-Note that Task Recorder **does not** capture screenshots from other tabs or of the user's desktop.
+Note that Task recorder **does not** capture screenshots from other tabs or of the user's desktop.
 
 ## Test generation
 
-After completing a business process recording using Task Recorder, a developer may import the recording file (.xml) into Visual Studio to create an X++ test. The Task Recorder Import Tool is able to generate a human-readable X++ test that translates any Recording gestures, Validations, or Tasks into the appropriate test code. 
+After completing a business process recording using Task recorder, a developer may import the recording file (.xml) into Visual Studio to create an X++ test. The Task recorder Import Tool is able to generate a human-readable X++ test that translates any Recording gestures, Validations, or tasks into the appropriate test code. 
 
 <!-- The Task Recorder Import Tool is able to generate a human-readable X++ test that translates any [Recording gestures](http://happydev/BabySteps/Pages/CTP6%20Platform%20HOLs%20and%20Docs/Task%20Recorder%20Guide%20-%20External.docx#_Recording_gestures), [Validations](http://happydev/BabySteps/Pages/CTP6%20Platform%20HOLs%20and%20Docs/Task%20Recorder%20Guide%20-%20External.docx#_Recording_controls) or [Tasks](http://happydev/BabySteps/Pages/CTP6%20Platform%20HOLs%20and%20Docs/Task%20Recorder%20Guide%20-%20External.docx#_Recording_controls) into the appropriate test code. -->
 
 ### Import a recorded test
 
 1.  Open Visual Studio with the **Dynamics development tools**.
-2.  **Go to Dynamics &gt; Addins &gt; Import Task recording**.
-3.  In the **Import Task Recording** menu, use the **Browse** button to locate a previously downloaded recording file.
+2.  **Go to Dynamics &gt; Addins &gt; Import task recording**.
+3.  In the **Import task recording** menu, use the **Browse** button to locate a previously downloaded recording file.
 4.  Optionally, choose to have the generated test code be added to the startup project. This requires that a solution containing a project is set as the startup project. This will place the generated X++ test into the same model as the project.
 5.  If creating a new project, select the Model for the project. The generated X++ test will be placed in this model. The model needs to have references to the TestEssentials model for the generated test to build successfully.
 6.  Click **Import**.
@@ -417,7 +417,7 @@ After completing a business process recording using Task Recorder, a developer m
 
 ## Work in progress
 
-### Controls that are known to have incomplete support for Task Recorder
+### Controls that are known to have incomplete support for Task recorder
 
 -   Table
 -   Filter pane, which is the filter that pops out from the left side
@@ -425,7 +425,7 @@ After completing a business process recording using Task Recorder, a developer m
 -   Enhanced Previews
     -   No planned support for recording gestures inside of enhanced previews. While recording, enhanced previews will be disabled.
 -   All extensible controls are unsupported (except Segmented Entry)
-    -   Extensible control owners need to individually build support for Task Recorder.
+    -   Extensible control owners need to individually build support for Task recorder.
 
 ### Controls that can be recorded, but have limited support for the Copy/Paste/Validate gestures
 
@@ -438,9 +438,9 @@ After completing a business process recording using Task Recorder, a developer m
 -   Message box
     -   You cannot validate the text in the message box.
 
-### Controls that are known to have incomplete support for being used in a Task guide
+### Controls that are known to have incomplete support for being used in a task guide
 
 - Filter, which is the Quick filter that appears above lists
-  -   Does not support displaying a "generic value" during the Task guide. Currently displays the value that was used during recording.
+  -   Does not support displaying a "generic value" during the task guide. Currently displays the value that was used during recording.
 - Filter pane, which is the filter that pops out from the left side
-  -   The Task guide does not point to the individual elements within the Filter pane that need to be clicked on.
+  -   The task guide does not point to the individual elements within the Filter pane that need to be clicked on.

--- a/articles/dev-itpro/user-interface/task-recorder.md
+++ b/articles/dev-itpro/user-interface/task-recorder.md
@@ -5,7 +5,7 @@ title: Task recorder
 description: This topic describes how to use Task recorder to record client functions.
 author: jasongre
 manager: AnnBe
-ms.date: 10/24/2017
+ms.date: 09/17/2018
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-platform

--- a/articles/dev-itpro/user-interface/task-recorder.md
+++ b/articles/dev-itpro/user-interface/task-recorder.md
@@ -117,9 +117,9 @@ Congratulations! You have created your first Task recording. You can proceed to 
 **Stop** is used to end the recording session. Ending the recording session isn't reversible, so the user should be sure that the recording is complete before clicking **Stop**. Clicking **Stop** will take the user to the download options screen.
 [![TaskRecorderGuide-TaskRecorderToolbarStop](./media/taskrecorderguide-taskrecordertoolbarstop.png)](./media/taskrecorderguide-taskrecordertoolbarstop.png)
 
-### Start/End Task
+### Start/End task
 
-**Start/End Task** enables a user to specify the beginning and ending of a set of grouped steps. Click the **Start Task** button to add a "Start Task" step to the end of the current list of recorded steps. Then perform the steps that you want to include in the task. After you've performed (and thus recorded) the steps in the task, click the **End Task** button to add an "End Task" step to the end of the current list of recorded steps.
+**Start/End task** enables a user to specify the beginning and ending of a set of grouped steps. Click the **Start Task** button to add a "Start Task" step to the end of the current list of recorded steps. Then perform the steps that you want to include in the task. After you've performed (and thus recorded) the steps in the task, click the **End Task** button to add an "End Task" step to the end of the current list of recorded steps.
 
 **Note**: You must start your tasks before performing/recording the steps that you want to include in the task. You must End the task after you have performed/recorded all of the steps that you want to include in the task.
 
@@ -128,9 +128,9 @@ Congratulations! You have created your first Task recording. You can proceed to 
 [![This image shows the location of the Start and End Task buttons, which are used to create Task groupings around sets of recorded steps.](./media/taskrecorderguide-taskrecorderrecordingcontrolstasks.png)](./media/taskrecorderguide-taskrecorderrecordingcontrolstasks.png)
 
 
-### Delete/Restore Step
+### Delete/Restore step
 
-**Delete/Restore Step** enables a user to remove steps from the recording, or undo the removal of a step from the recording. You must first select the step in the Steps list that you want to delete/restore, and then click the **Delete/Restore Step** button.
+**Delete/Restore step** enables a user to remove steps from the recording, or undo the removal of a step from the recording. You must first select the step in the Steps list that you want to delete/restore, and then click the **Delete/Restore step** button.
 
 > [!NOTE]
 > The behavior of the **Delete** button changes when in **Maintenance mode.** When deleting a pending/un-executed step in **Maintenance mode**, the step cannot be restored after playback has progressed past the point at which it would have executed the Deleted step. For example, you load a recording that contains 3 steps in Maintenance mode. Before starting playback, you delete step 2. You can restore step 2, as long as playback has not executed step 3. After you start playback, and playback has "skipped' step 2 (because you deleted it) and executed step 3, you will not be able to restore step 2. This is because step 2 was not executed and thus not recorded, and it cannot be retroactively added back into the recording at its previous position. 
@@ -145,9 +145,9 @@ Congratulations! You have created your first Task recording. You can proceed to 
 ## Adding annotations
 An **annotation** is any additional information that is associated with a step in a Task recording. Annotations contain information that is in addition to the information that is automatically recorded by Task Recorder.
 
-### Step Instruction
+### Step instruction
 
-The **Step Instruction** is the primary text that is displayed for this step in the Task guide. There are usually 2-3 alternative options for step instructions, and they appear in the following order when editing the annotation.
+The **Step instruction** is the primary text that is displayed for this step in the Task guide. There are usually 2-3 alternative options for step instructions, and they appear in the following order when editing the annotation.
 
 [![This image shows the annotation options for changing the Step instruction](./media/taskrecorderguide-annotationlabels.png)](./media/taskrecorderguide-annotationlabels.png) 
 
@@ -298,7 +298,7 @@ You can move steps under a sub-task without playing back or re-recording the ent
 If you want the first step in the task guide to be within a sub-task, create a sub-task step as the second step, and then move the first step into it. You can add or move as many steps or sub-tasks as needed.
 5.  When you are done editing the task guide, click **Done editing**, and then choose one of the options to save or publish the task guide.
 
-### Collapse Recording name and description
+### Collapse recording name and description
 
 You can expand and collapse the **Recording name** and **Recording description** fields. When these fields are collapsed, more steps will be visible in the Task recorder editing pane. 
 
@@ -357,11 +357,11 @@ Because the UI element is not visible on the screen, the Task guide pop-up will 
 
 In some cases, the Task guide pop-up will not mention the form by name. This is because the user may need to navigate to a dynamic form. A dynamic form is a form that is not modeled, frequently known as a runtime-generated form. These sorts of forms do not have a proper name. Some examples of runtime-generated forms include simple and custom lookups. The way for a user to navigate to a lookup form is to re-open the lookup.
 
-### Next & Previous step
+### Next & previous step
 
 These buttons appear on the Task guide pop-up and allow a user to manually control the flow of the Task guide. When clicking the Next or Previous step, the Task guide will move to the next or previous step in the guide. The Task guide does not check whether the user has completed a step before going to the next or previous step. The Task guide also ***never*** automatically completes any step for the user, even when using the Next and Previous Step options. Using the Next and Previous step buttons can result in producing an error state, if the previous or next step refers to a UI element that is on the current form. When the user is completing an Informational Step, the only way to proceed is to use the Next step button. This is required because an Informational Step does not represent an action that was recorded on any UI element. Since no action was recorded in the Task recording, the Task guide does not have the information necessary to know what action to expect the user to complete.
 
-### The "See More" button
+### The "See more" button
 
 Clicking this button will expand the Task guide pop-up to show additional information related to the step. The additional information is often optional reading material that is not required for the user to successfully complete the step. In the additional information, the user may see:
 -   An **Example** value
@@ -370,11 +370,11 @@ Clicking this button will expand the Task guide pop-up to show additional inform
 -   A **Note**
     -   A Note may contain scenario-specific information that will help provide context to the user about the current step of the Task guide.
 
-## Screenshot Extension setup 
+## Screenshot extension setup 
 
 ### Document generation setup (optional)
 
-Using a pre-release Chrome extension, Task Recorder is able to take screenshots of the browser as a user records a business process. After the user completes the recording, Task Recorder can then use these screenshots to generate Microsoft Word documents. To enable this functionality, follow the steps below to install the pre-release Google Chrome extension that enables Task Recorder to capture screenshots during recording.
+Using a **pre-release** Chrome extension, Task Recorder is able to take screenshots of the browser as a user records a business process. After the user completes the recording, Task Recorder can then use these screenshots to generate Microsoft Word documents. To enable this functionality, follow the steps below to install the pre-release Google Chrome extension that enables Task Recorder to capture screenshots during recording.
 
 1.  Open Google Chrome
 2.  Go to **Menu &gt; More tools &gt; Extensions**. 
@@ -389,7 +389,9 @@ Using a pre-release Chrome extension, Task Recorder is able to take screenshots 
 
 6.  Restart Chrome.
 
-Task Recorder will now take screenshots of the tab that has the client running. Task Recorder **does not** capture screenshots from other tabs or of the user's desktop.
+Task Recorder will now take screenshots of the tab that has the client running. These screenshots are only available for a certain period of time after the recording has been played. Starting in Platform Update 16, screenshots are available for a week after playback. Prior to that, the screenshots are only available for 10 minutes. If the screenshots have expired, you can regenerate them by playing the task recording again.  
+
+Note that Task Recorder **does not** capture screenshots from other tabs or of the user's desktop.
 
 ## Test generation
 


### PR DESCRIPTION
Added some content documenting how long screenshots are available and fixed some sentence case issues.  I also noticed some inconsistency in how we're capitalizing "task recorder" throughout the document.  If I could get some clarity on that, I may fix some additional things.  I assume "Task recorder" as a feature should be capitalized like this, but references to "task guides" or "task recordings" do not need to be capitalized at all.  