### PR TITLE
Update app-sealing-faq.md

### DIFF
--- a/articles/dev-itpro/extensibility/app-sealing-faq.md
+++ b/articles/dev-itpro/extensibility/app-sealing-faq.md
@@ -99,3 +99,8 @@ Some extensibility requests break changes. Some of the more common potentially b
 - Request: Make CountryRegionCode changeable via extension.
 - Problem: Starting with Platform update 14, changes to CountryRegionCode are supported if the CountryRegionCode property already has a value. Empty CountryRegionCode properties cannot be changed because that change is more restrictive (the element would now only be available for certain countries/regions) and therefore would be a breaking change.
 - Workaround: Use the existing CountryRegionCode extension capability when the element is already country/region specific.
+
+### Why can't the Table Field properties AllowEdit, AllowEditOnCreate, Mandatory or IgnoreEDTRelation be made extensible?
+- Request: Make Table Field properties AllowEdit, AllowEditOnCreate, Mandatory and/or IgnoreEDTRelation changeable via extension.
+- Problem: The ability to change the "Allow Edit", "Allow Edit On Create", "Mandatory" and "IgnoreEDTRelation" properties on Table Fields would result in breaking changes. Changing a field to allow editing changes the intent of the field. Denying editing a field can break existing behavior. Changing a relation breaks the original intent of that relation which is a breaking change. Making a field mandatory can result in breaking existing behavior.
+- Workaround: Add new Table Fields via extension and control those as needed.


### PR DESCRIPTION
Adding "Why can't the Table Field properties AllowEdit, AllowEditOnCreate, Mandatory or IgnoreEDTRelation be made extensible?"