### PR TITLE
Fix PowerShell syntax highlighting because of indentation issues

### DIFF
--- a/articles/dev-itpro/deployment/setup-deploy-on-premises-pu12.md
+++ b/articles/dev-itpro/deployment/setup-deploy-on-premises-pu12.md
@@ -802,16 +802,16 @@ Finance and Operations requires additional configuration beyond the default out-
 
 1. Configure the AD FS identifier so that it matches the AD FS token issuer.
 
-  This command is related to adding new users using the **Import users** option on the **Users** page (**System administration > Users > Users**) in the Finance and Operations client.
+   This command is related to adding new users using the **Import users** option on the **Users** page (**System administration > Users > Users**) in the Finance and Operations client.
 
-    ```powershell
+    ```PowerShell
     $adfsProperties = Get-AdfsProperties
     Set-AdfsProperties -Identifier $adfsProperties.IdTokenIssuer
     ```
 
 2. You should disable Windows Integrated Authentication (WIA) for intranet authentication connections, unless you've configured AD FS for mixed environments. For more information about how to configure WIA so that it can be used with AD FS, see [Configure browsers to use Windows Integrated Authentication (WIA) with AD FS](/windows-server/identity/ad-fs/operations/configure-ad-fs-browser-wia).
 
-  This command is related to using forms authentication upon signing into the Finance and Operations client. Other options, such as single sign-on, may be available which require additional setup.
+   This command is related to using forms authentication upon signing into the Finance and Operations client. Other options, such as single sign-on, may be available which require additional setup.
 
     ```powershell
     Set-AdfsGlobalAuthenticationPolicy -PrimaryIntranetAuthenticationProvider FormsAuthentication, MicrosoftPassportAuthentication
@@ -819,7 +819,7 @@ Finance and Operations requires additional configuration beyond the default out-
 
 3. For sign-in, the user's email address must be an acceptable authentication input.
 
-  This command is related to setting up email claims. Other options, such as transformation rules, may be available which require additional setup.
+   This command is related to setting up email claims. Other options, such as transformation rules, may be available which require additional setup.
 
     ```powershell
     Add-Type -AssemblyName System.Net


### PR DESCRIPTION
Hi guys, 
the syntax highlighting of the PowerShell code wasn't working because wrong indentation.