### PR TITLE
Adding troubleshoot section for: Ax-DatabaseSynchronize logs and solving AX: AADSTS50058 skype issue

### DIFF
--- a/articles/dev-itpro/deployment/troubleshoot-on-prem.md
+++ b/articles/dev-itpro/deployment/troubleshoot-on-prem.md
@@ -1070,3 +1070,24 @@ update SQLSYSTEMVARIABLES set VALUE = 12 where parm = 'SYSTIMEZONESVERSION'
 ## Printing randomly stops
 Ensure that all network printers that have been installed on the AOS server are running as the Windows service account that the AXService.EXE process is running as.
 
+## Ax-DatabaseSynchronize is not being populated with events
+Starting from PU20 and above, there is database synchronization log issue where the synchronization logs are not written in the event viewer under Ax-DatabaseSynchronize. 
+
+To resolve this issue:
+Go to <SF-dir>\AOS_<x>\ Fabric\work\Applications\AXSFType_App<X>\log - eg.:C:\ProgramData\SF\AOS_11\Fabric\work\Applications\AXSFType_App183\log
+Here you can see the output from Datadabase-sync in the Code_AXSF_M_<X>.out files. And trouble shoot any issues regarding this component.
+
+## Unable to access AX: AADSTS50058: A silent sign-in request was sent but no user is signed in
+This error might happen during login to AX. After entering user credentials, browser will show application layout for a second, then it will try to redirect outside of LBD and fail with following error:
+AADSTS50058: A silent sign-in request was sent but no user is signed in. The cookies used to represent the user's session were not sent in the request to Azure AD. This can happen if the user is using Internet Explorer or Edge, and the web app sending the silent sign-in request is in different IE security zone than the Azure AD endpoint (login.microsoftonline.com).
+This happens because there was a change in Skype Presence API and OnPrem environments are connecting to it by default.
+
+To resolve the issue:
+Run this SQL query: update [AXDB].[dbo].[SYSCLIENTPERF] set SkypeEnabled = 0
+OR 
+Turn off Skype Presence option in the following page:
+System administration -> Setup -> Client performance options -> Client internet connectivity -> Skype presence enabled
+In order to do so, one must login to AX. Redirection should be blocked in browser so user can login and perform that action. After disabling Skype presence, redirection can be unblocked again.
+Chrome browser blocks redirection by default.
+
+


### PR DESCRIPTION
Added two sections
- Workaround for DatabaseSynchronize Event Provider Channel is not deploying which results in Ax-DatabaseSynchronize is not being populated with events
- A fix for "AX: AADSTS50058: A silent sign-in request was sent but no user is signed in" 