### PR TITLE
Added example of accessing form elements from the form-nested extension class

### DIFF
--- a/articles/dev-itpro/extensibility/method-wrapping-coc.md
+++ b/articles/dev-itpro/extensibility/method-wrapping-coc.md
@@ -267,6 +267,8 @@ final class FormDataSource1_Extension
     {
         next init();
         //...
+        //use element.FormToExtendVariable to access form's variables and datasources
+        //element.FormToExtendMethod() to call form methods
     }
  
     public boolean validateWrite()


### PR DESCRIPTION
IntelliSense doesn't work inside form-nested extensions classes, so example of how to access form elements is provided
