### PR TITLE
Fix incorrect wording related to Retail events

### DIFF
--- a/articles/retail/dev-itpro/retail-component-events-diagnostics-troubleshooting.md
+++ b/articles/retail/dev-itpro/retail-component-events-diagnostics-troubleshooting.md
@@ -153,7 +153,7 @@ To access LCS Log Search, follow these steps.
 5.  On the **Environment details** page, click **Environment Monitoring**.
 6.  On the **Environment monitoring** page, click **View raw logs**.
 7.  On the **Log Search** page, select one of the following queries:
-    -   **Retail error events** query, which includes events from Retail Modern POS, Retail Cloud POS, and Retail Hardware Station
+    -   **Retail client events** query, which includes events from Retail Modern POS, Retail Cloud POS, and Retail Hardware Station
     -   **All logs** query, which includes data from Retail Server, Commerce Data Exchange, and Commerce Data Exchange: Real-time Service
 
 You can filter by the following criteria to refine your query:


### PR DESCRIPTION
Retail error events -> retail client events when talking about MPOS and CloudPOS events in LCS.

As pointed out in #474 