### PR TITLE
Update Cust Vend master data sharing section

### DIFF
--- a/articles/dev-itpro/sysadmin/cross-company-data-sharing.md
+++ b/articles/dev-itpro/sysadmin/cross-company-data-sharing.md
@@ -92,6 +92,11 @@ Cross-company data sharing isn't supported for the following scenarios:
 ## Customer and vendor master data sharing (preview)
 Customer and vendor master data sharing allows you to share customer and vendor data across multiple companies. This feature is available for customers on version 8.0 and later on a restricted basis. If you would like to be included in the preview program for this feature, complete the following survey and contact product support, [Data sharing application](https://aka.ms/MSDYN365FODataSharing).
 
+> [!NOTE]
+> Default dimensions setup against a customer or vendor, cannot be shared across companies. When configuring the customer or vendor record for cross-company data sharing, the DefaultDimension field is disabled, and cannot be included in the data sharing policy.
+>
+>Default dimensions hold a loose foreign key reference to the backing dimension data, which can reference both company specific and non-company specific data. Determining the appropriate action to be taken for each dimension value, has inherent complexity and would require a change from the current implementation, that could dramatically impact performance.
+
 ## Download a cross-company data sharing template from LCS
 1.  Sign in to LCS.
 2.  On the home page, click **Shared asset library**.

--- a/articles/dev-itpro/sysadmin/cross-company-data-sharing.md
+++ b/articles/dev-itpro/sysadmin/cross-company-data-sharing.md
@@ -5,7 +5,7 @@ title: Cross-company data sharing
 description: This topic provides information about cross-company data sharing. Cross-company sharing is a mechanism for sharing reference and group data among companies in a Microsoft Dynamics 365 for Finance and Operations deployment.
 author: aprilolson
 manager: AnnBe
-ms.date: 01/08/2018
+ms.date: 02/19/2019
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-platform
@@ -94,8 +94,8 @@ Customer and vendor master data sharing allows you to share customer and vendor 
 
 > [!NOTE]
 > Default dimensions set up against a customer or vendor cannot be shared across companies. When configuring the customer or vendor record for cross-company data sharing, the **DefaultDimension** field is disabled, and cannot be included in the data sharing policy.
->
-> Default dimensions hold a loose foreign key reference to the backing dimension data, which can reference both company- pecific and non-company specific data. Determining the appropriate action to be taken for each dimension value has inherent complexity and would require a change from the current implementation, that could dramatically impact performance.
+
+> Default dimensions hold a loose foreign key reference to the backing dimension data, which can reference both company-specific and non-company specific data. Determining the appropriate action to be taken for each dimension value has inherent complexity and would require a change from the current implementation, which could dramatically impact performance.
 
 ## Download a cross-company data sharing template from LCS
 1.  Sign in to LCS.

--- a/articles/dev-itpro/sysadmin/cross-company-data-sharing.md
+++ b/articles/dev-itpro/sysadmin/cross-company-data-sharing.md
@@ -93,9 +93,9 @@ Cross-company data sharing isn't supported for the following scenarios:
 Customer and vendor master data sharing allows you to share customer and vendor data across multiple companies. This feature is available for customers on version 8.0 and later on a restricted basis. If you would like to be included in the preview program for this feature, complete the following survey and contact product support, [Data sharing application](https://aka.ms/MSDYN365FODataSharing).
 
 > [!NOTE]
-> Default dimensions setup against a customer or vendor, cannot be shared across companies. When configuring the customer or vendor record for cross-company data sharing, the DefaultDimension field is disabled, and cannot be included in the data sharing policy.
+> Default dimensions set up against a customer or vendor cannot be shared across companies. When configuring the customer or vendor record for cross-company data sharing, the **DefaultDimension** field is disabled, and cannot be included in the data sharing policy.
 >
->Default dimensions hold a loose foreign key reference to the backing dimension data, which can reference both company specific and non-company specific data. Determining the appropriate action to be taken for each dimension value, has inherent complexity and would require a change from the current implementation, that could dramatically impact performance.
+> Default dimensions hold a loose foreign key reference to the backing dimension data, which can reference both company- pecific and non-company specific data. Determining the appropriate action to be taken for each dimension value has inherent complexity and would require a change from the current implementation, that could dramatically impact performance.
 
 ## Download a cross-company data sharing template from LCS
 1.  Sign in to LCS.


### PR DESCRIPTION
DefaultDimension field cannot be included in the data sharing policy, so we should tell customers this and provide some explanation as to why.