### PR TITLE
Remove comma in GetAzureWriteUrl api post example

### DIFF
--- a/articles/dev-itpro/data-entities/data-management-api.md
+++ b/articles/dev-itpro/data-entities/data-management-api.md
@@ -139,7 +139,7 @@ The **GetAzureWritableUrl** API is used to get a writable blob URL. The method i
 POST /data/DataManagementDefinitionGroups/Microsoft.Dynamics.DataEntities.GetAzureWriteUrl
 BODY
 {
-    "uniqueFileName":"<string>",
+    "uniqueFileName":"<string>"
 }
 ```
 


### PR DESCRIPTION
The comma in the example `post` causes an exception in D365.