### PR TITLE
Update apac-ind-loc-deployment-guidelines.md

### DIFF
--- a/articles/retail/localizations/apac-ind-loc-deployment-guidelines.md
+++ b/articles/retail/localizations/apac-ind-loc-deployment-guidelines.md
@@ -94,6 +94,9 @@ The CRT extension components are included in the CRT samples. To complete the fo
     <add source="assembly" value="Contoso.Commerce.Runtime.Extensions.GenericTaxEngine" />
     ```
 
+    > [!WARNING]
+    > Do **not** edit the commerceruntime.config and CommerceRuntime.MPOSOffline.config files. These files aren't intended for any customizations.
+    
 # [Retail 7.3.2 and later](#tab/retail-7-3-2)
 
 1. Find the **Runtime.Extensions.GenericTaxEngine** project, and build it.
@@ -136,6 +139,9 @@ The CRT extension components are included in the CRT samples. To complete the fo
     <add source="assembly" value="Contoso.Commerce.Runtime.GenericTaxEngine" />
     ```
 
+    > [!WARNING]
+    > Do **not** edit the commerceruntime.config and CommerceRuntime.MPOSOffline.config files. These files aren't intended for any customizations.
+    
 # [Retail 8.1.3 and later](#tab/retail-8-1-3)
 
 1. Find the **Runtime.Extensions.GenericTaxEngine** project, and build it.
@@ -178,6 +184,9 @@ The CRT extension components are included in the CRT samples. To complete the fo
     <add source="assembly" value="Contoso.Commerce.Runtime.GenericTaxEngine" />
     ```
 
+    > [!WARNING]
+    > Do **not** edit the commerceruntime.config and CommerceRuntime.MPOSOffline.config files. These files aren't intended for any customizations.
+    
 # [Retail 10.0 and later](#tab/retail-10-0)
 
 The Generic Tax Engine component is a part of sealed extensions.
@@ -192,9 +201,9 @@ The Generic Tax Engine component is a part of sealed extensions.
     ``` xml
     <add source="assembly" value="Microsoft.Dynamics.Commerce.Runtime.GenericTaxEngine" />
     ```
-    
-> [!WARNING]
-> Do **not** edit the commerceruntime.config and CommerceRuntime.MPOSOffline.config files. These files aren't intended for any customizations.
+
+    > [!WARNING]
+    > Do **not** edit the commerceruntime.config and CommerceRuntime.MPOSOffline.config files. These files aren't intended for any customizations.
 
 ### Set up required parameters in Retail headquarters
 

--- a/articles/retail/localizations/apac-ind-loc-deployment-guidelines.md
+++ b/articles/retail/localizations/apac-ind-loc-deployment-guidelines.md
@@ -205,6 +205,8 @@ The Generic Tax Engine component is a part of sealed extensions.
     > [!WARNING]
     > Do **not** edit the commerceruntime.config and CommerceRuntime.MPOSOffline.config files. These files aren't intended for any customizations.
 
+---
+
 ### Set up required parameters in Retail headquarters
 
 For more information, see [GST integration for cash registers for India](./apac-ind-cash-registers.md).

--- a/articles/retail/localizations/apac-ind-loc-deployment-guidelines.md
+++ b/articles/retail/localizations/apac-ind-loc-deployment-guidelines.md
@@ -3,7 +3,7 @@
 
 title: Deployment guidelines for cash registers for India
 description: This topic is a deployment guide for the Retail localization for India.
-author: 
+author: AlexChern0v
 manager: ralin
 ms.date: 01/31/2019
 ms.topic: article


### PR DESCRIPTION
The sections after warning message were put into the last version Retail 10.0 and later. For details please see [link](https://docs.microsoft.com/en-us/dynamics365/unified-operations/retail/localizations/apac-ind-loc-deployment-guidelines?toc=%2Ffin-and-ops%2Ftoc.json&tabs=retail-10-0), so move the warning message into the section of the versions individually. 