### PR TITLE
Removed enabling change tracking from main SQL

### DIFF
--- a/articles/dev-itpro/database/dbmovement-scenario-debugdiag.md
+++ b/articles/dev-itpro/database/dbmovement-scenario-debugdiag.md
@@ -116,7 +116,6 @@ SET T1.storageproviderid = 0
 FROM docuvalue T1
 WHERE T1.storageproviderid = 1 --Azure storage
 
-ALTER DATABASE [<your AX database name>] SET CHANGE_TRACKING = ON (CHANGE_RETENTION = 6 DAYS, AUTO_CLEANUP = ON)
 GO
 DROP PROCEDURE IF EXISTS SP_ConfigureTablesForChangeTracking
 DROP PROCEDURE IF EXISTS SP_ConfigureTablesForChangeTracking_V2


### PR DESCRIPTION
SQL to update the database already contains the SQL for enabling change tracking.
Removed that so that user doesnt have to turn it off if the script was not edited before running