### PR TITLE
Update synchronize-project-list.md

### DIFF
--- a/articles/supply-chain/sales-marketing/synchronize-project-list.md
+++ b/articles/supply-chain/sales-marketing/synchronize-project-list.md
@@ -5,7 +5,7 @@ title: Synchronize project list from Finance and Operations to Field Service
 description: This topic discusses the templates and underlying tasks that are used to synchronize projects from Microsoft Dynamics 365 for Finance and Operations to Microsoft Dynamics 365 for Field Service.
 author: ChristianRytt
 manager: AnnBe
-ms.date: 01/14/2019
+ms.date: 03/13/2019
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-applications

--- a/articles/supply-chain/sales-marketing/synchronize-project-list.md
+++ b/articles/supply-chain/sales-marketing/synchronize-project-list.md
@@ -42,13 +42,13 @@ This topic discusses the templates and underlying tasks that are used to synchro
 The following template and underlying tasks are used to run synchronization of projects from Microsoft Dynamics 365 for Finance and Operations to Microsoft Dynamics 365 for Field Service.
 
 **Template in Data integration**
-- Projects (Finance and Operations to Field Service)
+- Projects (Fin and Ops to Field Service)
 
 **Task in the Data integration project**
 - Projects
 
 The following synchronization tasks are required before synchronization of project list can occur:
-- Accounts (Sales to Finance and Operations) 
+- Accounts (Sales to Fin and Ops) 
 
 ## Entity set
 | Field Service           | Finance and Operations  |
@@ -68,6 +68,6 @@ Enable change tracking for Data entity projects.
 ## Template mapping in Data integration
 
 
-### Projects (Finance and Operations to Field Service): Projects
+### Projects (Fin and Ops to Field Service): Projects
 
 [![Template mapping in Data integration](./media/FSProject1.png)](./media/FSProject1.png)


### PR DESCRIPTION
Please note that "Fin and Ops" should not be changed to Finance and Operations, as it is referring to the released template names - e.g. "Work Orders with Project (Field Service to Fin and Ops)" we are allowed to use Fin and Ops here. Main reason being that the template name has a max number characters that would be excited with the full name.