### PR TITLE
Update register-items-basic-warehousing.md

### DIFF
--- a/articles/supply-chain/warehousing/tasks/register-items-basic-warehousing.md
+++ b/articles/supply-chain/warehousing/tasks/register-items-basic-warehousing.md
@@ -30,7 +30,7 @@ ms.dyn365.ops.version: Version 7.0.0
 
 [!include [task guide banner](../../includes/task-guide-banner.md)]
 
-This procedure shows you how to register items using the item arrival journal when you are using “basic warehousing” in the Inventory management module. This would usually be done by a receiving clerk. You can run this procedure in demo data company USMF with the example values that are shown.  If you are not using USMF, you need to have a confirmed purchase order with an open purchase order line before you start this guide. The item on the line must be stocked, and it must not use product variants, and must not have tracking dimensions. And the item needs to be associated with a storage dimension group, where site and warehouse are active.
+This procedure shows you how to register items using the item arrival journal when you are using “basic warehousing” in the Inventory management module. This would usually be done by a receiving clerk. You can run this procedure in demo data company USMF with the example values that are shown.  If you are not using USMF, you need to have a confirmed purchase order with an open purchase order line before you start this guide. The item on the line must be stocked. And the item needs to be associated with a storage dimension group, where site and warehouse are active.
 
 
 ## Create item arrival journal header


### PR DESCRIPTION
This is my final change for tag #1083. 
The text that I copied from this article as following are wrong. PO doesn't have to be confirmed.  You can use it for items with variants, the item can also have active tracking dimensions. 

> you need to have a confirmed purchase order
> The item on the line must be stocked, and it must not use product variants, and must not have tracking dimensions.