### PR TITLE
Correcting isBusinessEventEnabled sample

### DIFF
--- a/articles/dev-itpro/business-events/business-events-dev-doc.md
+++ b/articles/dev-itpro/business-events/business-events-dev-doc.md
@@ -432,8 +432,7 @@ The sending of a business event is linked to the commit of the underlying transa
 The business events framework determines whether a business event is published to a consumer. As a general rule, applications should always send a business event, regardless of whether the business event is enabled. If significant additional logic is required, or if the logic for sending a business event has a performance impact, an application can check whether a specific business event is enabled before it runs business logic that is associated with sending business events. This check is done through the **BusinessEventsConfigurationReader::isBusinessEventEnabled** method.
 
 ```
-if (BusinessEventsConfigurationReader::isBusinessEventEnabled(new
-CollectionStatusUpdatedBusinessEvent()))
+if (BusinessEventsConfigurationReader::isBusinessEventEnabled(classStr(CollectionStatusUpdatedBusinessEvent)))
 {
     while select dispute
     where dispute.Status == CustVendDisputeStatus::PromiseToPay


### PR DESCRIPTION
Correcting BusinessEventsConfigurationReader::isBusinessEventEnabled usage example to pass in classStr and not a new object