### PR TITLE
Renaming reverse proxy to proxy

### DIFF
--- a/articles/dev-itpro/deployment/onprem-reverseproxy.md
+++ b/articles/dev-itpro/deployment/onprem-reverseproxy.md
@@ -1,8 +1,8 @@
 ---
 # required metadata
 
-title: Configure reverse proxies for on-premises environments
-description: This topic describes how you can secure the Dynamics 365 for Finance and Operations on-premises environment behind a reverse proxy.
+title: Configure proxies for on-premises environments
+description: This topic describes how you can secure the Dynamics 365 for Finance and Operations on-premises environment behind a proxy.
 author: sarvanisathish
 manager: AnnBe
 ms.date: 02/06/2018
@@ -27,13 +27,13 @@ ms.search.validFrom: 2017-06-30
 ms.dyn365.ops.version: Platform update 8 
 ---
 
-# Configure reverse proxies for on-premises environments
+# Configure proxies for on-premises environments
 
 [!include [banner](../includes/banner.md)]
 
-You may want to secure the Dynamics 365 for Finance and Operations on-premises environment behind a reverse proxy. Reverse proxy is a server that hides the actual servers serving traffic from the clients. The proxy server accepts requests from the clients on behalf of the Finance and Operations environment and forwards the traffic to it. The clients are not aware of the actual servers that compose the Finance and Operations environment. This adds another measure of security and enables load balancing. 
+You may want to secure the Dynamics 365 for Finance and Operations on-premises environment behind a proxy. Proxy is a server that hides the actual servers serving traffic from the clients. The proxy server accepts requests from the clients on behalf of the Finance and Operations environment and forwards the traffic to it. The clients are not aware of the actual servers that compose the Finance and Operations environment. This adds another measure of security and enables load balancing. 
 
-## Configure the reverse proxy
+## Configure the proxy
 
 Perform the following steps in **each** node of type **OrchestratorType** in the Microsoft Azure Service Fabric cluster.
 

--- a/articles/dev-itpro/deployment/onprem-reverseproxy.md
+++ b/articles/dev-itpro/deployment/onprem-reverseproxy.md
@@ -5,7 +5,7 @@ title: Configure proxies for on-premises environments
 description: This topic describes how you can secure the Dynamics 365 for Finance and Operations on-premises environment behind a proxy.
 author: sarvanisathish
 manager: AnnBe
-ms.date: 02/06/2018
+ms.date: 04/30/2019
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-platform


### PR DESCRIPTION
The front end server that handles the a request that originated from a client is a forward-proxy. In our case, the AOS is creating the request and hence becomes the client. Hence the proxy server becomes a forward-proxy. Agreed with PM to just name it proxy.