### PR TITLE
Fix broken code example about using namespaces

### DIFF
--- a/articles/dev-itpro/dev-ref/xpp-variables-data-types.md
+++ b/articles/dev-itpro/dev-ref/xpp-variables-data-types.md
@@ -115,7 +115,7 @@ A *variable* is an identifier that points to a memory location where information
             al = new Alist();
             str s;
             al.Add(1);
-            s.IONS.Path::ChangeExtension(@"c:\tmp\test.xml", ".txt");
+            IONS.Path::ChangeExtension(@"c:\tmp\test.xml", ".txt");
         }
     }
 

--- a/articles/dev-itpro/dev-ref/xpp-variables-data-types.md
+++ b/articles/dev-itpro/dev-ref/xpp-variables-data-types.md
@@ -5,7 +5,7 @@ title: X++ variables and data types
 description: This topic describes variables and data types in X++.
 author: RobinARH
 manager: AnnBe
-ms.date: 06/20/2017
+ms.date: 05/16/2019
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-platform


### PR DESCRIPTION
Identifier 's' in front of the namespace alias 'IONS' does not make sense and results in a compiler error.