### PR TITLE
Refer to highest layer when comparing with USR

### DIFF
--- a/articles/dev-itpro/extensibility/modify-edt.md
+++ b/articles/dev-itpro/extensibility/modify-edt.md
@@ -57,7 +57,7 @@ You can view the created extensions in the Application Explorer in Visual Studio
 ![Modify EDT](media/EDT03.jpg) 
 
 ## If the EDT is modified in more than one model
-If multiple ISVs have extended the same extended data type, the properties of the EDT from the model with the highest Model ID (closest to USR) will be used. If there are multiple models with changes in the same layer, changes from the model with the highest Model ID will be used. For example, if ISV 1 modified the label of ItemId to “Awesome item number” in model AwesomeModel (USR layer) with ID 15, while ISV 2 modified the label of ItemId to “Super item number” in model SuperModel (USR layer) with ID 12, the end user would see “Awesome item number” in the user interface instead of “Item number”.
+If multiple ISVs have extended the same extended data type, the properties of the EDT from the model with the highest layer (closest to USR) will be used. If there are multiple models with changes in the same layer, changes from the model with the highest Model ID will be used. For example, if ISV 1 modified the label of ItemId to “Awesome item number” in model AwesomeModel (USR layer) with ID 15, while ISV 2 modified the label of ItemId to “Super item number” in model SuperModel (USR layer) with ID 12, the end user would see “Awesome item number” in the user interface instead of “Item number”.
 
 > [!NOTE]
 > Instead of extending an existing EDT, you can create a new one, deriving it from the existing EDT. This allows you to edit more properties than you could edit using the extension approach. This means that you would need to modify the fields using this EDT to use your new EDT.


### PR DESCRIPTION
Currently the text compares the model ID with the relative position to the USR layer, which IMHO does not make sense as both concepts are orthogonal.
The correct comparison should probably be between the models' layers and USR.