### PR TITLE
Update operations-scheduling.md

### DIFF
--- a/articles/supply-chain/production-control/operations-scheduling.md
+++ b/articles/supply-chain/production-control/operations-scheduling.md
@@ -5,7 +5,7 @@ title: Operations scheduling
 description: This topic provides information about operations scheduling. You can use operations scheduling to provide a general estimate of the production process over time.
 author: ChristianRytt
 manager: AnnBe
-ms.date: 06/20/2017
+ms.date: 06/20/2019
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-applications
@@ -72,8 +72,8 @@ The operations schedule also drives master planning and determines calculations 
 -   **Material availability** – Inventory, subproductions, suppliers, and vendors
 -   **Capacity availability** – Resources that are required for production
 
-> [Note!]
-When using multi-threaded master planning and Operations scheduling then finite capacity will not considered. 
+> [!NOTE]
+> If you're using multi-threaded master planning and operations scheduling, finite capacity will not be considered. 
 
 ## Cancellations
 When you run operations scheduling, you can cancel specific parts of the routing. These parts include the queue time, setup time, process time, overlap time, and transport times.

--- a/articles/supply-chain/production-control/operations-scheduling.md
+++ b/articles/supply-chain/production-control/operations-scheduling.md
@@ -72,6 +72,9 @@ The operations schedule also drives master planning and determines calculations 
 -   **Material availability** – Inventory, subproductions, suppliers, and vendors
 -   **Capacity availability** – Resources that are required for production
 
+> [Note!]
+When using multi-threaded master planning and Operations scheduling then finiste capacity will not considered. 
+
 ## Cancellations
 When you run operations scheduling, you can cancel specific parts of the routing. These parts include the queue time, setup time, process time, overlap time, and transport times.
 

--- a/articles/supply-chain/production-control/operations-scheduling.md
+++ b/articles/supply-chain/production-control/operations-scheduling.md
@@ -73,7 +73,7 @@ The operations schedule also drives master planning and determines calculations 
 -   **Capacity availability** – Resources that are required for production
 
 > [Note!]
-When using multi-threaded master planning and Operations scheduling then finiste capacity will not considered. 
+When using multi-threaded master planning and Operations scheduling then finite capacity will not considered. 
 
 ## Cancellations
 When you run operations scheduling, you can cancel specific parts of the routing. These parts include the queue time, setup time, process time, overlap time, and transport times.


### PR DESCRIPTION
Adding 
> [Note!]
When using multi-threaded master planning and Operations scheduling then finiste capacity is never considered. 

It has been the cause for support cases. Need to include it in the documentation.