### PR TITLE
Removed duplicate sentence

### DIFF
--- a/articles/financials/general-ledger/posting-definitions.md
+++ b/articles/financials/general-ledger/posting-definitions.md
@@ -5,7 +5,7 @@ title: Posting definitions
 description: This article provides information about posting definitions, and how to define and link them. For supported posting types and documents, you can use posting definitions instead of posting profiles to classify main accounts and financial dimensions on accounting entries.
 author: ShylaThompson
 manager: AnnBe
-ms.date: 06/20/2017
+ms.date: 09/03/2019
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-applications

--- a/articles/financials/general-ledger/posting-definitions.md
+++ b/articles/financials/general-ledger/posting-definitions.md
@@ -34,8 +34,7 @@ ms.dyn365.ops.version: AX 7.0.0
 
 [!include [banner](../includes/banner.md)]
 
-This article provides information about posting definitions, and how to define and link them. For supported posting types and documents, you can use posting definitions instead of posting profiles to classify main accounts and financial dimensions on accounting entries.
-
+This article provides information about posting definitions, and how to define and link them.
 For supported posting types and documents, you can use posting definitions instead of posting profiles to classify main accounts and financial dimensions on accounting entries. You can view the supported documents and posting types on the **Transaction posting definitions** page. 
 
 To start using posting definitions, select the **Use posting definitions** option on the **General ledger parameters** page. Even when you use posting definitions, you must still define posting profiles for the originating entries and non-supported posting types and documents. 


### PR DESCRIPTION
Removed the duplicate sentence "For supported posting types and documents, you can use posting definitions instead of posting profiles to classify main accounts and financial dimensions on accounting entries."