### PR TITLE
Remove BaseX version information.

### DIFF
--- a/articles/fin-ops-core/dev-itpro/dev-tools/install-basex.md
+++ b/articles/fin-ops-core/dev-itpro/dev-tools/install-basex.md
@@ -90,8 +90,6 @@ Download the zip package from the download page.
 
 ---
 
-Currently, the latest version is 9.1.2.
-
 ## Install BaseX
 
 # [Admin: Install BaseX](#tab/admin)


### PR DESCRIPTION
The version information is far outdated and will be shortly again if we name the latest version. It's better not to mention it.