### PR TITLE
Update cross-company-data-sharing.md

### DIFF
--- a/articles/fin-ops-core/dev-itpro/sysadmin/cross-company-data-sharing.md
+++ b/articles/fin-ops-core/dev-itpro/sysadmin/cross-company-data-sharing.md
@@ -5,7 +5,7 @@ title: Cross-company data sharing
 description: This topic provides information about cross-company data sharing. Cross-company sharing is a mechanism for sharing reference and group data among companies in a Finance and Operations deployment.
 author: aprilolson
 manager: AnnBe
-ms.date: 02/19/2019
+ms.date: 11/05/2019
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-platform
@@ -90,7 +90,7 @@ Cross-company data sharing isn't supported for the following scenarios:
 -   Master data management
 
 ## Customer and vendor master data sharing
-Customer and vendor master data sharing allows you to share customer and vendor data across multiple companies. This feature is available for customers on version 8.0 and later on an application basis. If you would like to be conisidered for this feature, complete the following survey and contact product support, [Data sharing application](https://aka.ms/MSDYN365FODataSharing).
+Customer and vendor master data sharing allows you to share customer and vendor data across multiple companies. This feature is available for customers on version 8.0 and later. If you would like to be considered for this feature, complete the following survey and contact Support, [Data sharing application](https://aka.ms/MSDYN365FODataSharing).
 
 > [!NOTE]
 > Default dimensions set up against a customer or vendor cannot be shared across companies. When configuring the customer or vendor record for cross-company data sharing, the **DefaultDimension** field is disabled, and cannot be included in the data sharing policy.

--- a/articles/fin-ops-core/dev-itpro/sysadmin/cross-company-data-sharing.md
+++ b/articles/fin-ops-core/dev-itpro/sysadmin/cross-company-data-sharing.md
@@ -89,8 +89,8 @@ Cross-company data sharing isn't supported for the following scenarios:
 -   Complex scenarios, such as replication of subtype/supertype tables or tables that have date effectivity rules
 -   Master data management
 
-## Customer and vendor master data sharing (preview)
-Customer and vendor master data sharing allows you to share customer and vendor data across multiple companies. This feature is available for customers on version 8.0 and later on a restricted basis. If you would like to be included in the preview program for this feature, complete the following survey and contact product support, [Data sharing application](https://aka.ms/MSDYN365FODataSharing).
+## Customer and vendor master data sharing
+Customer and vendor master data sharing allows you to share customer and vendor data across multiple companies. This feature is available for customers on version 8.0 and later on an application basis. If you would like to be conisidered for this feature, complete the following survey and contact product support, [Data sharing application](https://aka.ms/MSDYN365FODataSharing).
 
 > [!NOTE]
 > Default dimensions set up against a customer or vendor cannot be shared across companies. When configuring the customer or vendor record for cross-company data sharing, the **DefaultDimension** field is disabled, and cannot be included in the data sharing policy.


### PR DESCRIPTION
The Customer and vendor data sharing feature, in its current design, will never become generally available. Thus we will keep it restricted based on application approval. We want to remove the preview label since this is resulting in confusion and a lot of questions.