### PR TITLE
Give the new Https URL to AxErd

### DIFF
--- a/articles/fin-ops-core/fin-ops/get-started/axerd-retired.md
+++ b/articles/fin-ops-core/fin-ops/get-started/axerd-retired.md
@@ -34,13 +34,13 @@ ms.dyn365.ops.version: AX 2012
 
 [!include [banner](../includes/banner.md)]
 
-We've unfortunately had to retire the AxErd web page from the `microsoft.com` domain. However, AxErd may still be available elsewhere, hosted by thrid parties.
+We've unfortunately had to retire the AxErd web page from the `microsoft.com` domain. However, AxErd may still be available elsewhere, hosted by third parties.
 
 AxErd provided Entity relationship diagrams (ERDs) for many Microsoft Dynamics AX 2012 tables.
 
 ## Source on GitHub
 
-We've been able to post both the source code for the project, and the HTML files for the web page in a GitHub repo: https://github.com/Microsoft/ax-2012-doc-tools
+We've been able to post both the source code for the project, and the HTML files for the web page, in a GitHub repo: https://github.com/Microsoft/ax-2012-doc-tools
 
 The HTML pages are in the repo, at [https://github.com/Microsoft/ax-2012-doc-tools/tree/master/AxErd/AxErd/_RelatedFiles_AxErd/Deploy/Default.htm](https://github.com/Microsoft/ax-2012-doc-tools/tree/master/AxErd/AxErd/_RelatedFiles_AxErd/Deploy/Default.htm)
 
@@ -48,7 +48,7 @@ A description of how to create your own ERDs is at: [https://github.com/Microsof
 
 The solution is at the root of the AxErd folder [https://github.com/Microsoft/ax-2012-doc-tools/tree/master/AxErd](https://github.com/Microsoft/ax-2012-doc-tools/tree/master/AxErd).
 
-## AxERD resurrected on third party website
+## AxErd resurrected on third-party website
 
 In March 2018, a third party copied the AxErd source from GitHub, and redeployed AxErd at the following site. The site is still operating as of March 2020:
 

--- a/articles/fin-ops-core/fin-ops/get-started/axerd-retired.md
+++ b/articles/fin-ops-core/fin-ops/get-started/axerd-retired.md
@@ -5,7 +5,7 @@ title: AxErd page has been retired
 description: We've had to retire the AxErd page. We've been able to post both the source code for the project, and the HTML files for the web page in a GitHub repo. 
 author: margoc
 manager: AnnBe
-ms.date: 02/27/2018
+ms.date: 03/06/2020
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-platform
@@ -15,7 +15,7 @@ ms.technology:
 
 # ms.search.form: 
 # ROBOTS: 
-audience: Application User
+audience: IT Pro, Developer
 # ms.devlang: 
 ms.reviewer: sericks
 ms.search.scope: AX 2012
@@ -34,7 +34,7 @@ ms.dyn365.ops.version: AX 2012
 
 [!include [banner](../includes/banner.md)]
 
-We've unfortunately had to retire the AxErd web page, from the `microsoft.com` domain. However, AxErd may still be available elsewhere, hosted by thrid parties.
+We've unfortunately had to retire the AxErd web page from the `microsoft.com` domain. However, AxErd may still be available elsewhere, hosted by thrid parties.
 
 AxErd provided Entity relationship diagrams (ERDs) for many Microsoft Dynamics AX 2012 tables.
 

--- a/articles/fin-ops-core/fin-ops/get-started/axerd-retired.md
+++ b/articles/fin-ops-core/fin-ops/get-started/axerd-retired.md
@@ -34,10 +34,22 @@ ms.dyn365.ops.version: AX 2012
 
 [!include [banner](../includes/banner.md)]
 
-We've unfortunately had to retire the AxErd web page, which provided Entity relationship diagrams (ERDs) for many Microsoft Dynamics AX 2012 tables. We've been able to post both the source code for the project, and the HTML files for the web page in a GitHub repo: https://github.com/Microsoft/ax-2012-doc-tools
+We've unfortunately had to retire the AxErd web page, from the `microsoft.com` domain. However, AxErd may still be available elsewhere, hosted by thrid parties.
+
+AxErd provided Entity relationship diagrams (ERDs) for many Microsoft Dynamics AX 2012 tables.
+
+## Source on GitHub
+
+We've been able to post both the source code for the project, and the HTML files for the web page in a GitHub repo: https://github.com/Microsoft/ax-2012-doc-tools
 
 The HTML pages are in the repo, at [https://github.com/Microsoft/ax-2012-doc-tools/tree/master/AxErd/AxErd/_RelatedFiles_AxErd/Deploy/Default.htm](https://github.com/Microsoft/ax-2012-doc-tools/tree/master/AxErd/AxErd/_RelatedFiles_AxErd/Deploy/Default.htm)
 
 A description of how to create your own ERDs is at: [https://github.com/Microsoft/ax-2012-doc-tools/blob/master/AxErd/AxErd/_RelatedFiles_AxErd/Deploy/Help-HowToUse-AxErd.htm](https://github.com/Microsoft/ax-2012-doc-tools/blob/master/AxErd/AxErd/_RelatedFiles_AxErd/Deploy/Help-HowToUse-AxErd.htm)
 
 The solution is at the root of the AxErd folder [https://github.com/Microsoft/ax-2012-doc-tools/tree/master/AxErd](https://github.com/Microsoft/ax-2012-doc-tools/tree/master/AxErd).
+
+## AxERD resurrected on third party website
+
+In March 2018, a third party copied the AxErd source from GitHub, and redeployed AxErd at the following site. The site is still operating as of March 2020:
+
+- [https://AlexDMeyer.com/ax2012erd/](https://AlexDMeyer.com/ax2012erd/)


### PR DESCRIPTION
Hello PR Reviewer,
Alex D. Meyer is a member of the Dynamics AX User Group. Here is the post that Alex added to AxUg.com back on March 2018, when he resurrected AxErd:

https://www.axug.com/axug/communities/community-home/digestviewer/viewthread?MessageKey=8a74b251-e0ed-4f52-9833-dc4f2e39c1b8&CommunityKey=af0dadbe-c222-4660-9d1e-a9e3416c837a&tab=digestviewer#bm8a74b251-e0ed-4f52-9833-dc4f2e39c1b8

This proposed article edit is preferable to the alternative of - editing **FWLink 296623** by making its target Https URL be Alex's website.

FWIWorth, I was the Dyn AX employee who developed AxErd originally.

Thanks. (GeneMi = MightyPen)