### PR TITLE
Removed "Extend standard indexes"

### DIFF
--- a/articles/fin-ops-core/dev-itpro/extensibility/add-index.md
+++ b/articles/fin-ops-core/dev-itpro/extensibility/add-index.md
@@ -44,16 +44,3 @@ In the following illustration, an InventTable extension is used to define an ind
 
 > [!WARNING]
 > You should not use this approach to create unique indexes. This change is an intrusive change that might break the solutions of other independent software vendors (ISVs) if those solutions are deployed in the same environment. This capability will be removed in future platform releases.
-
-## Extend standard indexes
-
-You can extend standard indexes and add additional (included) columns but there are some conditions:
-
-+	The index is non-clustered.
-+	The index is not unique.
-
-The following constraints apply to extending a standard index:
-
-+	You cannot delete existing columns.
-+ You cannot change the order of the existing columns.
-+	You cannot disable standard indexes.

--- a/articles/fin-ops-core/dev-itpro/extensibility/add-index.md
+++ b/articles/fin-ops-core/dev-itpro/extensibility/add-index.md
@@ -6,7 +6,7 @@ title: Add indexes to tables through extension
 description: This topic describes how to add an index to a table.
 author: ivanv-microsoft
 manager: AnnBe
-ms.date: 07/29/2019
+ms.date: 03/09/2020
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-platform


### PR DESCRIPTION
This is not provided by the tooling. Might have been planned but is not implemented and won't be as far as I know. The documentation causes confusion (see https://www.yammer.com/dynamicsaxfeedbackprograms/#/Threads/show?threadId=577643815092224, for instance).