### PR TITLE
Licensing Guide link

### DIFF
--- a/articles/fin-ops-core/fin-ops/includes/banner.md
+++ b/articles/fin-ops-core/fin-ops/includes/banner.md
@@ -1,3 +1,3 @@
 > [!IMPORTANT]
-> Dynamics 365 for Finance and Operations has evolved into purpose-built applications to help you manage specific business functions. For more information about these changes, see [Dynamics 365 Licensing Guide](https://mbs.microsoft.com/Files/public/365/Dynamics365LicensingGuide.pdf).
+> Dynamics 365 for Finance and Operations has evolved into purpose-built applications to help you manage specific business functions. For more information about these changes, see [Dynamics 365 Licensing Guide](https://go.microsoft.com/fwlink/?LinkId=866544&clcid=0x409).
  


### PR DESCRIPTION
The currently displayed link (https://mbs.microsoft.com/Files/public/365/Dynamics365LicensingGuide.pdf) points to an outdated version of the Licensing Guide (July 2019). The go.microsoft.com link I put is the one which is used by https://dynamics.microsoft.com/en-us/pricing/ and points to the latest version (currently Feb 2020).