### PR TITLE
Updating Service Requests SLAs.

### DIFF
--- a/articles/fin-ops-core/dev-itpro/lifecycle-services/submit-request-dynamics-service-engineering-team.md
+++ b/articles/fin-ops-core/dev-itpro/lifecycle-services/submit-request-dynamics-service-engineering-team.md
@@ -126,9 +126,9 @@ Here are some typical examples of service requests that will be denied:
 | Service request type           | Applicable environments | Requested service | Lead time | Downtime |
 |--------------------------------|-------------------------|-------------------|-----------|----------|
 | Environment deployment         | Any | Environment deployment | Service level agreement (SLA): within two business days | |
-| Package application            | Production | Deployable package application | Five hours | Based on data volume |
+| Package application            | Production | Deployable package application | Five hours | Five hours |
 | Sandbox point-in-time restore | Any Tier 2 or higher sandbox | Database point-in-time restore | Five hours | Four hours |
-| Production point-in-time restore | Production | Database point-in-time restore | Five hours | Based on data volume |
+| Production point-in-time restore | Production | Database point-in-time restore | Based on data volume | Based on data volume |
 | Sandbox to Production          | Tier 2 or higher sandbox to Production | Sandbox to Production | Five hours | Four hours |
 | Other                          | Production | Maintenance mode | Five hours | Not applicable, because the customer indicates in the service request when the environment should be taken out of maintenance mode again |
 |                                | Production | IP safe list rules | Five hours | Two hours |

--- a/articles/fin-ops-core/dev-itpro/lifecycle-services/submit-request-dynamics-service-engineering-team.md
+++ b/articles/fin-ops-core/dev-itpro/lifecycle-services/submit-request-dynamics-service-engineering-team.md
@@ -5,7 +5,7 @@ title: Submit service requests to the Dynamics Service Engineering team
 description: This topic explains how you can submit service requests directly to the Dynamics Service Engineering team by using Microsoft Dynamics Lifecycle Services (LCS). 
 author: laneswenka
 manager: AnnBe
-ms.date: 06/15/2020
+ms.date: 06/22/2020
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-platform


### PR DESCRIPTION
Updating Service requests SLAs.
Package application downtime is now 5 hours (but for real this time) following Sync engine deliverable FinOps 245735
Correcting Production PITR lead time.