### PR TITLE
note to changes made in the web editor

### DIFF
--- a/articles/fin-ops-core/dev-itpro/analytics/customize-analytical-workspace.md
+++ b/articles/fin-ops-core/dev-itpro/analytics/customize-analytical-workspace.md
@@ -5,7 +5,7 @@ title: Customize embedded reports in analytical workspaces
 description: This topic describes how power users can customize the application reports that are embedded in analytical workspaces.
 author: TJVass
 manager: AnnBe
-ms.date: 04/17/2020
+ms.date: 06/29/2020
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-platform
@@ -86,7 +86,7 @@ To customize the embedded application solutions, a user must be a member of the 
 5. After you've completed your report customizations, select the **Save** button to promote the report edits. Customizations to the report are reflected immediately in the service. Therefore, users in your organization have access to the latest innovations.
 
     > [!NOTE]
-    > Customizations made in the web editor are not saved back to the underlying pbix report and are not retrievable if the pbix report is later customized on a development environment.
+    > Customizations made in the web editor are not saved back to the underlying PBIX report and are not retrievable if the PBIX report is later customized on a development environment.
 
 ## Restore the standard application solution
 

--- a/articles/fin-ops-core/dev-itpro/analytics/customize-analytical-workspace.md
+++ b/articles/fin-ops-core/dev-itpro/analytics/customize-analytical-workspace.md
@@ -85,6 +85,9 @@ To customize the embedded application solutions, a user must be a member of the 
 4. Use the Power BI web designer tools to customize the report canvas. The intuitive web controls let you perform typical actions such as adding and removing visuals, changing visual types, and formatting the content. You can also inspect the source of the report visualizations to make sure that decisions are based on the most relevant data that is available in the system. For more information, see [Add visualizations to a Power BI report](https://docs.microsoft.com/power-bi/visuals/power-bi-report-add-visualizations-i).
 5. After you've completed your report customizations, select the **Save** button to promote the report edits. Customizations to the report are reflected immediately in the service. Therefore, users in your organization have access to the latest innovations.
 
+    > [!NOTE]
+    > Customizations made in the web editor are not saved back to the underlying pbix report and are not retrievable if the pbix report is later customized on a development environment.
+
 ## Restore the standard application solution
 
 Follow these steps to restore the analytical workspaces that are bundled with the application solution.


### PR DESCRIPTION
We had a customer that had extensively customized an embedded report via the web editor and they went back to then edit over those changes on a Dev server believing their changes from the web would be available to the PBIX to then edit in PowerBI Desktop on a dev environment.  This is not the case and they were quite upset that the feature to SAVE customizations didn't allow them to access those or retrieve the modified PBIX file.  The likely missed the other section where we do call out the fact that customizations are not exportable so it may be ideal if we call it out again in a Note as edited.  Had they known that they wouldn't have invested as much time in editing in the web form and just done it from the dev machine with PowerBI Desktop so they could manage those edits going forward with change control.