### PR TITLE
Update whats-new-changed-10-0-8.md

### DIFF
--- a/articles/finance/get-started/whats-new-changed-10-0-8.md
+++ b/articles/finance/get-started/whats-new-changed-10-0-8.md
@@ -43,7 +43,7 @@ The following features are included in this release. The feature titles link to 
 
 - [Financial report retention policies](https://docs.microsoft.com/dynamics365-release-plan/2019wave2/dynamics365-finance/financial-report-retention-policies)
 
-- [Retained earnings calculation enhancements for financial reporting when using currency translation](https://docs.microsoft.com/dynamics365-release-plan/2019wave2/dynamics365-finance/retained-earnings-calculation-enhancements-financial-reporting-when-using-currency-translation)
+- [Retained earnings calculation enhancements for financial reporting when using currency translation](https://docs.microsoft.com/dynamics365-release-plan/2020wave1/dynamics365-finance/retained-earnings-calculation-enhancements-financial-reporting-when-using-currency-translation)
 
 - [Purchase agreement enhancements](https://docs.microsoft.com/dynamics365-release-plan/2019wave2/dynamics365-supply-chain-management/purchase-agreement-enhancements) 
 


### PR DESCRIPTION
There are a bad link for topic "Retained earnings calculation enhancements for financial reporting when using currency translation". Just update it to a proper link, that the feature looks like post pone to release in August 2020.