### PR TITLE
Improved code quality of sample defaultCTQuery()

### DIFF
--- a/articles/fin-ops-core/dev-itpro/data-entities/entity-change-track.md
+++ b/articles/fin-ops-core/dev-itpro/data-entities/entity-change-track.md
@@ -68,19 +68,21 @@ The following example shows how to add a static method to an entity. You must ma
 
 ```xpp
 public static Query defaultCTQuery()
-    {
-        Query q;
-        q = new Query();
-        QueryBuildDataSource qbd = q.addDataSource(tablename2id('CustTable'));
-        qbd = qbd.addDataSource(tablename2id('DirPartyTable'));
-        qbd.relations(true);
-        qbd = qbd.addDataSource(tablename2id('DirPartyLocation'));
-        qbd.addRange(fieldname2id(tablename2id('DirPartyLocation'),'IsPrimary')).value("1");
-        qbd.relations(false);
-        qbd.addLink(fieldName2Id(tableName2Id('DirPartyTable'),'RecId'),fieldName2Id(tableName2Id('DirPartyLocation'),'Party'));
-        qbd = qbd.addDataSource(tableName2Id('LogisticsPostalAddress'));
-        qbd.relations(false);
-        qbd.addLink(fieldName2Id(tableName2Id('DirPartyLocation'),'Location'),fieldName2Id(tableName2Id('LogisticsPostalAddress'),'Location'));
-        return q;
-    }
+{
+	Query q = new Query();    
+    
+	QueryBuildDataSource custDs = query.addDataSource(tableNum(CustTable));
+
+	QueryBuildDataSource partyDs = custDs.addDataSource(tableNum(DirPartyTable));
+	partyDs.relations(true);
+
+	QueryBuildDataSource locationDs = partyDs.addDataSource(tableNum(DirPartyLocation));
+	locationDs.addRange(fieldNum(DirPartyLocation, IsPrimary)).value(queryValue(NoYes::Yes));        
+	locationDs.addLink(fieldNum(DirPartyTable, RecId), fieldNum(DirPartyLocation, Party));
+
+	QueryBuildDataSource addressDs = locationDs.addDataSource(tableStr(LogisticsPostalAddress));        
+	addressDs.addLink(fieldNum(DirPartyLocation, Location), fieldNum(LogisticsPostalAddress, Location));
+
+	return q;
+}
 ```

--- a/articles/fin-ops-core/dev-itpro/data-entities/entity-change-track.md
+++ b/articles/fin-ops-core/dev-itpro/data-entities/entity-change-track.md
@@ -5,7 +5,7 @@ title: Enable change tracking for entities
 description: Use change tracking to enable incremental export of data from Finance and Operations.
 author: Milindav2
 manager: AnnBe
-ms.date: 07/07/2020
+ms.date: 09/17/2020
 ms.topic: article
 ms.prod: 
 ms.service: dynamics-ax-platform

--- a/articles/fin-ops-core/dev-itpro/data-entities/entity-change-track.md
+++ b/articles/fin-ops-core/dev-itpro/data-entities/entity-change-track.md
@@ -71,7 +71,7 @@ public static Query defaultCTQuery()
 {
 	Query q = new Query();    
     
-	QueryBuildDataSource custDs = query.addDataSource(tableNum(CustTable));
+	QueryBuildDataSource custDs = q.addDataSource(tableNum(CustTable));
 
 	QueryBuildDataSource partyDs = custDs.addDataSource(tableNum(DirPartyTable));
 	partyDs.relations(true);


### PR DESCRIPTION
While the sample implementation of defaultCTQuery() returns a correct result, it violates important best practices and people would learn bad practices from Microsoft.
For example, look at `fieldName2Id(tableName2Id('DirPartyTable'),'RecId')`. It's over-complicated and it uses hard-coded texts instead of intrinsic functions. The names wouldn't be checked at compile time and they wouldn't be included in cross-references. The correct implementation is `fieldNum(DirPartyTable, RecId)`.
I've also used descriptive variable names and an enum instead of the hard-coded numeric string (used as the range value).