### PR TITLE
Add a missing parenthesis

### DIFF
--- a/articles/commerce/dev-itpro/adyen-connector.md
+++ b/articles/commerce/dev-itpro/adyen-connector.md
@@ -267,7 +267,7 @@ The following table shows the set of features that the Dynamics 365 Payment Conn
 | Omni Channel Tokenization | ✔ | ✔ |
 | Linked Refunds | ✔<br>(Starting with 10.0.1) | ✔<br>(Starting with 10.0.1) |
 | [Save online payments](../dev-itpro/adyen-connector-listPI.md) | | ✔<br>(Starting with 10.0.2) | 
-| [External gift cards for call center and e-commerce] (https://docs.microsoft.com/dynamics365/commerce/dev-itpro/gift-card | ✔<br>(Starting with 10.0.10) | 
+| [External gift cards for call center and e-commerce] (https://docs.microsoft.com/dynamics365/commerce/dev-itpro/gift-card) | ✔<br>(Starting with 10.0.10) | 
 | [SCA payment redirect](https://go.microsoft.com/fwlink/?linkid=2131175) | | ✔<br>(Starting with 10.0.12) |
 | [Dedicated payment terminals and prompts for a printer and cash drawer](https://docs.microsoft.com/dynamics365/commerce/pos-multi-hws) | ✔<br>(Starting with 10.0.12) | |
 | [SDK-level tipping support through the Adyen connector](tipping.md) | ✔<br>(Starting with 10.0.14) | |


### PR DESCRIPTION
This is a minor markdown issue with a URL. In the [Supported Dynamics 365 payment features](https://docs.microsoft.com/en-us/dynamics365/commerce/dev-itpro/adyen-connector?tabs=10-0-14#supported-dynamics-365-payment-features), notice that the URL is displayed correctly.

Actual: 
`[External gift cards for call center and e-commerce](https://docs.microsoft.com/dynamics365/commerce/dev-itpro/gift-card`

Notice the closing parentheses is missing, which causes the URL to display poorly.

Proposed:
[External gift cards for call center and e-commerce](https://docs.microsoft.com/dynamics365/commerce/dev-itpro/gift-card)