### PR TITLE
Update SalesInvoiceHeaderV2Entity-invoice.md

### DIFF
--- a/articles/fin-ops-core/dev-itpro/data-entities/dual-write/includes/SalesInvoiceHeaderV2Entity-invoice.md
+++ b/articles/fin-ops-core/dev-itpro/data-entities/dual-write/includes/SalesInvoiceHeaderV2Entity-invoice.md
@@ -1,6 +1,6 @@
 ## Sales invoice headers V2 to invoices
 
-This template synchronizes data between Finance and Operations apps and Dataverse.
+This template synchronizes data between Finance and Operations apps and Dataverse. Please note that Sales invoice headers V2 entity in Finance and Operations contains invoices for Sales orders and Free text invoices. A filter is applied in Dataverse for dual write that will filter out any Free text invoice documents. 
 
 Source filter: `(SalesOrderNumber != "")`
 

--- a/articles/fin-ops-core/dev-itpro/data-entities/dual-write/includes/SalesInvoiceHeaderV2Entity-invoice.md
+++ b/articles/fin-ops-core/dev-itpro/data-entities/dual-write/includes/SalesInvoiceHeaderV2Entity-invoice.md
@@ -1,6 +1,6 @@
 ## Sales invoice headers V2 to invoices
 
-This template synchronizes data between Finance and Operations apps and Dataverse. Please note that Sales invoice headers V2 entity in Finance and Operations contains invoices for Sales orders and Free text invoices. A filter is applied in Dataverse for dual write that will filter out any Free text invoice documents. 
+This template synchronizes data between Finance and Operations apps and Dataverse. Note that the Sales invoice headers V2 entity in Finance and Operations contains invoices for sales orders and free text invoices. A filter is applied in Dataverse for dual-write that will filter out any free text invoice documents. 
 
 Source filter: `(SalesOrderNumber != "")`
 


### PR DESCRIPTION
Adding detail that Sales invoice header v2 contains Sales orders and Free text invoices but Dataverse will filter out any Free text invoice documents. We have seen tickets where customers are expecting to see Free text invoice documents synchronize and they only see Sales order documents synchronize.