### PR TITLE
Update to FAQ for default storage location

### DIFF
--- a/articles/fin-ops-core/fin-ops/organization-administration/configure-document-management.md
+++ b/articles/fin-ops-core/fin-ops/organization-administration/configure-document-management.md
@@ -245,9 +245,9 @@ File types include Microsoft Word documents and images. A file type is denoted b
 
 Yes. SharePoint storage is supported natively and can be selected as the storage location for a document type. In addition, any URL addressable file can be made an attachment via the **URL** document type.
 
-### What is the default storage location for attachments in Finance & Operations environments?
+### What is the default storage location for attachments in Finance + Operations environments?
 
-Attachments are saved in Azure Blob storage automatically by default as part of the product cloud offering.
+By default, attachments are saved in Azure Blob storage automatically as part of the product cloud offering.
 
 ### If I accidentally delete an attachment stored in Azure Blob storage, can it be restored?
 

--- a/articles/fin-ops-core/fin-ops/organization-administration/configure-document-management.md
+++ b/articles/fin-ops-core/fin-ops/organization-administration/configure-document-management.md
@@ -245,9 +245,9 @@ File types include Microsoft Word documents and images. A file type is denoted b
 
 Yes. SharePoint storage is supported natively and can be selected as the storage location for a document type. In addition, any URL addressable file can be made an attachment via the **URL** document type.
 
-### How does the default storage location for Document Management change in Finance + Operations environments?
+### What is the default storage location for attachments in Finance & Operations environments?
 
-For Finance + Operations, the Azure Blob storage provider for attachments is replaced by a file folder storage provider so that attachments are kept on-premises instead of being stored in the cloud. Therefore, the default storage location for attachments is a file folder.
+Attachments are saved in Azure Blob storage automatically by default as part of the product cloud offering.
 
 ### If I accidentally delete an attachment stored in Azure Blob storage, can it be restored?
 


### PR DESCRIPTION
Replaced FAQ section 'How does the default storage location for Document Management change in Finance + Operations environments?' with question 'What is the default storage location for attachments in Finance & Operations environments?'. File storage is not an option in the F&O cloud offering and uses Azure blob storage by default.