### PR TITLE
Update SQL Server parameters for license import

### DIFF
--- a/articles/fin-ops-core/dev-itpro/dev-tools/isv-licensing.md
+++ b/articles/fin-ops-core/dev-itpro/dev-tools/isv-licensing.md
@@ -170,14 +170,15 @@ Follow these steps to enable licensing for your solution.
     | --metadatadir                 | Use this parameter to specify the metadata directory. You should use the default packages directory.   |
     | --bindir                      | Use this parameter to specify the binaries directory. You should use the default packages directory.   |
     | --sqlserver                   | Use this parameter to specify the Microsoft SQL Server. For one-box environment, use a period (**.**). |
-    | --sqluser                     | Use this parameter to specify the SQL Server user. You should pass in **AOSUser**.                     |
+    | --sqldatabase                 | Use this parameter to specify the SQL Server database. For one-box environments, pass in **AXDB**.     |
+    | --sqluser                     | Use this parameter to specify the SQL Server user. You should pass in **axdbadminr**.                  |
     | --sqlpwd                      | Use this parameter to specify the SQL Server password.                                                 |
     | --licensefilename             | Use this parameter to specify the license file that will be loaded.                                    |
 
     Here is an example.
 
     ```Console
-    C:\AOSService\PackagesLocalDirectory\Bin\Microsoft.Dynamics.AX.Deployment.Setup.exe --setupmode importlicensefile --metadatadir c:\packages --bindir c:\packages --sqlserver . --sqldatabase axdbrain --sqluser AOSUser --sqlpwd ******** --licensefilename c:\templicense.txt
+    C:\AOSService\PackagesLocalDirectory\Bin\Microsoft.Dynamics.AX.Deployment.Setup.exe --setupmode importlicensefile --metadatadir c:\packages --bindir c:\packages --sqlserver . --sqldatabase axdb --sqluser axdbadmin --sqlpwd ******** --licensefilename c:\templicense.txt
     ```
 
 4.  The corresponding configuration key will be available and enabled on the **License configuration** page. By default, the configuration is enabled. For example, see the **ISVConfigurationKey1** configuration key in the following screenshot. 

--- a/articles/fin-ops-core/dev-itpro/dev-tools/isv-licensing.md
+++ b/articles/fin-ops-core/dev-itpro/dev-tools/isv-licensing.md
@@ -170,8 +170,8 @@ Follow these steps to enable licensing for your solution.
     | --metadatadir                 | Use this parameter to specify the metadata directory. You should use the default packages directory.   |
     | --bindir                      | Use this parameter to specify the binaries directory. You should use the default packages directory.   |
     | --sqlserver                   | Use this parameter to specify the Microsoft SQL Server. For one-box environment, use a period (**.**). |
-    | --sqldatabase                 | Use this parameter to specify the SQL Server database. For one-box environments, pass in **AXDB**.     |
-    | --sqluser                     | Use this parameter to specify the SQL Server user. You should pass in **axdbadminr**.                  |
+    | --sqldatabase                 | Use this parameter to specify the SQL Server database. For one-box environments, use **AXDB**.     |
+    | --sqluser                     | Use this parameter to specify the SQL Server user. You should use **axdbadminr**.                  |
     | --sqlpwd                      | Use this parameter to specify the SQL Server password.                                                 |
     | --licensefilename             | Use this parameter to specify the license file that will be loaded.                                    |
 


### PR DESCRIPTION
Update the parameters -sgldatabase and -sqluser to reflect the actual names cloud hosted environments are deployed with. Also adding -sqldatabase to the table list of parameters.