### PR TITLE
Clarified how snapshots are created.

### DIFF
--- a/articles/fin-ops-core/dev-itpro/perf-test/rsat/rsat-tutorial.md
+++ b/articles/fin-ops-core/dev-itpro/perf-test/rsat/rsat-tutorial.md
@@ -84,13 +84,19 @@ After the test case is run, the message in the Excel parameter file is compared 
 
 This feature takes screenshots of the steps that were performed during task recording. It is useful for auditing or debugging purposes.
 
-- To use this feature, open the **Microsoft.Dynamics.RegressionSuite.WindowsApp.exe.config** file under the RSAT installation folder (for example, **C:\\Program Files (x86)\\Regression Suite Automation Tool**), and change the value of the following element from **false** to **true**.
+- To use this feature while running RSAT with the user interface, open the **Microsoft.Dynamics.RegressionSuite.WindowsApp.exe.config** file under the RSAT installation folder (for example, **C:\\Program Files (x86)\\Regression Suite Automation Tool**), and change the value of the following element from **false** to **true**.
 
     ```xml
     <add key="VerboseSnapshotsEnabled" value="false" />
     ```
 
-When your run the test case, RSAT will generate snapshots (images) of the steps in the playback folder of the test cases in the working diretory. If you are using an older version of RSAT, the images are saved to **C:\\Users\\\<Username\>\\AppData\\Roaming\\regressionTool\\playback**, a separate folder is created for each test case that is run.
+- To use this feature while running RSAT by the CLI like from DevOps, open the **Microsoft.Dynamics.RegressionSuite.ConsoleApp.exe.config** file under the RSAT installation folder (for example, **C:\\Program Files (x86)\\Regression Suite Automation Tool**), and change the value of the following element from **false** to **true**.
+
+    ```xml
+    <add key="VerboseSnapshotsEnabled" value="false" />
+    ```
+
+When your then run test cases, RSAT will generate snapshots (images) of the steps and save these under the playback folder of the test cases in the working diretory. Under the playback folders a separate sub-folder is created called **StepSnapshots** that will contain snapshots for the test case that is run.
 
 ## Assignment
 


### PR DESCRIPTION
There was a missing distinction between RSAT run with client vs CLI that was added, plus removed old legacy storage reference which is no longer relevant and was found confusing some users.