### PR TITLE
The current help page discourages users from using the plan filter functionality

### DIFF
--- a/articles/supply-chain/master-planning/planning-optimization/plan-filters.md
+++ b/articles/supply-chain/master-planning/planning-optimization/plan-filters.md
@@ -46,7 +46,7 @@ A plan filter is set up that includes items A, B, and C. Master planning runs ar
 - **Runtime filter that includes all items (blank filter):** Items A, B, and C are included in the planning run, and the previous planning output for items A and B is overwritten.
 
 > [!NOTE]
-> You should avoid setting a plan filter on the plan that is selected as **Current dynamic master plan** on the **Master planning parameters** page. Otherwise, the dynamic master plan functionality will be limited to the filtered items. For example, if the net requirements are updated for an item that isn't part of the plan filter, no result will be generated.
+> If you set plan filter on the plan that is selected as **Current dynamic master plan** on the **Master planning parameters** page then the dynamic master plan functionality will be limited to the filtered items. For example, if the net requirements are updated for an item that isn't part of the plan filter, no result will be generated.
 
 ## Related resources
 


### PR DESCRIPTION
The current help page discourages users from using the plan filter functionality. On the contrary, we should encourage use of plan filters when appropriate.