### PR TITLE
Add a section for credit notes

### DIFF
--- a/articles/commerce/dev-itpro/commerce-payments.md
+++ b/articles/commerce/dev-itpro/commerce-payments.md
@@ -201,6 +201,20 @@ After the payments are edited, the order submission process corrects any changes
 | Unlinked refunds | If the merchant's return policies and the payment processor allow this approach, unlinked refunds can be specified for return orders in cases where the order was originally paid in cash, for example, or in cases where the original card that was used for payment is no longer active. | Yes |
 | Refunds to non-card prepayments | Return orders that were originally paid through non-card prepayments, such as cash or credit memo payments, won't be subject to linked refund. An appropriate payment method, such as **Check**, must be specified for the refund payment. Organizations that allow unlinked refunds can refund non-card prepayments to credit cards that weren't previously used for the order, if the payment processor allows this approach. | Yes |
 
+### Credit notes
+
+If a customer wants to return items or be reimbursed for items or services that you have sold and received payment for, you must create and post a sales credit memo that specifies the requested change. To include the correct sales invoice information, you can create the sales credit memo directly from the posted sales invoice or you can create a new sales credit memo with copied invoice information.
+
+- Accounts receivable > All sales orders > Open an existing sales order > Sell > Credit note
+- Accounts receivable > All sales orders > Create a new sales order > Sell > Credit note
+
+If you need more control of the sales return process, such as warehouse documents for the item handling or better overview when receiving items from multiple sales documents with one sales return, then you can create sales return orders. A sales return order automatically issues the related sales credit memo and other return-related documents, such as a replacement sales order, if needed.
+
+- Accounts receivable > All return orders > Create a new return order
+- Retail and Commerce > Customers > Customer service > Select the customer account > Select the invoiced order > Create a new return order
+
+**Note**: A credit memo created from the existing sales order will *not* provide the option to invoice the order.
+
 ### Edit and remove orders that have prepayments
 
 | Scenario | Description | Supported |


### PR DESCRIPTION
Described how to create credit notes for a Commerce order. The options to create a credit note will be the same after enabling the feature. However, invoicing the credit note will not be available when the credit note is created from the existing sales order.