### PR TITLE
Correcting addProperties CoC example to include next()

### DIFF
--- a/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
+++ b/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
@@ -609,9 +609,9 @@ A custom payload context must be extended from the **BusinessEventsCommitLogPayl
 class CustomCommitLogPayloadContext extends BusinessEventsCommitLogPayloadContext
 {
     private utcdatetime eventTime;
-    public utcdatetime parmEventTime(utcdatetime \_eventTime = eventTime)
+    public utcdatetime parmEventTime(utcdatetime _eventTime = eventTime)
     {
-        eventTime = \_eventTime;
+        eventTime = _eventTime;
         return eventTime;
     }
 }
@@ -626,7 +626,7 @@ A Chain of Command (CoC) extension must be written for the **BusinessEventsSende
 public final class CustomPayloadContextBusinessEventsSender_Extension
 {
     protected BusinessEventsCommitLogPayloadContext
-    buildPayloadContext(BusinessEventsCommitLogEntry \_commitLogEntry)
+    buildPayloadContext(BusinessEventsCommitLogEntry _commitLogEntry)
     {
         BusinessEventsCommitLogPayloadContext payloadContext = next
         buildPayloadContext(_commitLogEntry);
@@ -646,6 +646,8 @@ Adapters that consume payload context are written in such a way that they expose
 The **BusinessEventsServiceBusAdapter** class has the CoC method that is named **addProperties**.
 
 ```xpp
+using Microsoft.ServiceBus.Messaging;
+
 [ExtensionOf(classStr(BusinessEventsServiceBusAdapter))]
 public final class CustomBusinessEventsServiceBusAdapter_Extension
 {
@@ -663,6 +665,27 @@ public final class CustomBusinessEventsServiceBusAdapter_Extension
             customPayloadContext.parmBusinessEventCategory()));
             propertyBag.Add('LegalEntity', customPayloadContext.parmLegalEntity());
             propertyBag.Add('EventTime', customPayloadContext.parmEventTime());
+        }
+    }
+}
+```
+
+
+The **BusinessEventsEventGridAdapter** class has the CoC method that is named **setContextProperties**. The following example shows what this step looks like for the Event Grid Adapter. The eventGridMessage has a Subject that can be filtered on.
+```xpp
+using Microsoft.Azure.EventGrid.Models;
+
+[ExtensionOf(classStr(BusinessEventsEventGridAdapter))]
+public final class CustomBusinessEventsEventGridAdapter_Extension
+{
+    protected void setContextProperties(EventGridEvent _eventGridEvent, BusinessEventsEndpointPayloadContext _context)
+    {
+        next setContextProperties(_eventGridEvent, _context);
+        if (_context is CustomCommitLogPayloadContext)
+        {
+            CustomCommitLogPayloadContext customPayloadContext = _context as CustomCommitLogPayloadContext;
+
+            _eventGridEvent.Subject = _eventGridEvent.Subject + customPayloadContext.parmLegalEntity();
         }
     }
 }
@@ -704,10 +727,9 @@ The **initialize** method should be implemented to check the type of the **Busin
 if (!(_endpoint is CustomBusinessEventsEndpoint))
 {
     BusinessEventsEndpointManager::logUnknownEndpointRecord(tableStr(CustomBusinessEventsEndpoint),
-    \_endpoint.RecId);
+    _endpoint.RecId);
 }
-CustomBusinessEventsEndpoint customBusinessEventsEndpoint = \_endpoint as
-CustomBusinessEventsEndpoint;
+CustomBusinessEventsEndpoint customBusinessEventsEndpoint = _endpoint as CustomBusinessEventsEndpoint;
 customField = customBusinessEventsEndpoint.CustomField;
 if (!customField)
 {

--- a/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
+++ b/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
@@ -672,6 +672,7 @@ public final class CustomBusinessEventsServiceBusAdapter_Extension
 
 
 The **BusinessEventsEventGridAdapter** class has the CoC method that is named **setContextProperties**. The following example shows what this step looks like for the Event Grid Adapter. The eventGridMessage has a Subject that can be filtered on.
+
 ```xpp
 using Microsoft.Azure.EventGrid.Models;
 

--- a/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
+++ b/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
@@ -649,14 +649,13 @@ The **BusinessEventsServiceBusAdapter** class has the CoC method that is named *
 [ExtensionOf(classStr(BusinessEventsServiceBusAdapter))]
 public final class CustomBusinessEventsServiceBusAdapter_Extension
 {
-    protected void addProperties(BrokeredMessage \_message,
-    BusinessEventsEndpointPayloadContext \_context)
+    protected void addProperties(BrokeredMessage _message, BusinessEventsEndpointPayloadContext _context)
     {
+        next addProperties(_message, _context);
         if (_context is CustomCommitLogPayloadContext)
         {
-            CustomCommitLogPayloadContext customPayloadContext = \_context as
-            CustomCommitLogPayloadContext;
-            var propertyBag = \_message.Properties;
+            CustomCommitLogPayloadContext customPayloadContext = _context as CustomCommitLogPayloadContext;
+            var propertyBag = _message.Properties;
             propertyBag.Add('EventId', customPayloadContext.parmEventId());
             propertyBag.Add('BusinessEventId', customPayloadContext.parmBusinessEventId());
             // Convert the enum to string to be able to serialize the property.

--- a/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
+++ b/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
@@ -4,7 +4,7 @@
 title: Business events developer documentation
 description: This topic walks you through the development process and best practices for implementing business events.
 author: Sunil-Garg
-ms.date: 09/19/2019
+ms.date: 11/24/2021
 ms.topic: article
 ms.prod: 
 ms.technology: 


### PR DESCRIPTION
Correcting addProperties CoC example to include next() call.
Removing unnecessary back slashes \