### PR TITLE
Adding docs on getExtendedBusinessEventsContractName

### DIFF
--- a/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
+++ b/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
@@ -574,13 +574,17 @@ extends BusinessEventsContract
 }
 ```
 
-#### Step 6: Wrap the buildContract method
+#### Step 6: Extend the business event class to wrap the buildContract and getExtendedBusinessEventsContractName methods
 
-Provide a build contract implementation that calls **next** to load the standard business event contract and populates any payload extensions. Here is the complete class.
+Provide a **buildContract** implementation that calls **next** to load the standard business event contract and populates any payload extensions. 
+
+Provide a the name of your new contract implementation through an extension of the **getExtendedBusinessEventsContractName** method. This will allow the new contract name and fields to be present in the UI of the Business Events catalog. (Note: Failing to provide a getExtendedBusinessEventsContractName extension only means that the extended contract fields won't be available in the UI. Sending is unaffected and will always have your extended fields.)
+
+Here is the complete class.
 
 ```xpp
 [ExtensionOf(classStr(CustFreeTextInvoicePostedBusinessEvent))]
-public final class FreeTextInvoicePostedBusinessEventContract_Extension
+public final class CustFreeTextInvoicePostedBusinessEvent_Extension
 {
     public BusinessEventsContract buildContract()
     {
@@ -589,6 +593,13 @@ public final class FreeTextInvoicePostedBusinessEventContract_Extension
         buildContract());
         businessEventContract.parmCustomerClassification(CustomerClassifier::deriveCustomerClassification(businessEventContract.parmInvoiceAccount()));
         return businessEventContract;
+    }
+    
+    public BusinessEventsContractEDT getExtendedBusinessEventsContractName()
+    {
+        next getExtendedBusinessEventsContractName();
+
+        return classStr(CustFreeTextInvoicePostedBusinessEventExtendedContract);
     }
 }
 ```

--- a/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
+++ b/articles/fin-ops-core/dev-itpro/business-events/business-events-dev-doc.md
@@ -4,7 +4,7 @@
 title: Business events developer documentation
 description: This topic walks you through the development process and best practices for implementing business events.
 author: jaredha
-ms.date: 11/24/2021
+ms.date: 02/08/2022
 ms.topic: article
 ms.prod: 
 ms.technology: 
@@ -578,7 +578,10 @@ extends BusinessEventsContract
 
 Provide a **buildContract** implementation that calls **next** to load the standard business event contract and populates any payload extensions. 
 
-Provide a the name of your new contract implementation through an extension of the **getExtendedBusinessEventsContractName** method. This will allow the new contract name and fields to be present in the UI of the Business Events catalog. (Note: Failing to provide a getExtendedBusinessEventsContractName extension only means that the extended contract fields won't be available in the UI. Sending is unaffected and will always have your extended fields.)
+Provide the name of your new contract implementation through an extension of the **getExtendedBusinessEventsContractName** method. This will allow the new contract name and fields to be present in the UI of the Business Events catalog. 
+
+> [!Note]
+> Failing to provide a getExtendedBusinessEventsContractName extension only means that the extended contract fields won't be available in the UI. Sending is unaffected and will always have your extended fields.
 
 Here is the complete class.
 


### PR DESCRIPTION
Adding information on how to extend getExtendedBusinessEventsContractName to have extended contract fields display in the Business Events catalog UI.
See bug where this functionality was added in PU50.
https://msdyneng.visualstudio.com/FinOps/_workitems/edit/559461