### PR TITLE
Update xpp-static-classes.md

### DIFF
--- a/articles/fin-ops-core/dev-itpro/dev-ref/xpp-static-classes.md
+++ b/articles/fin-ops-core/dev-itpro/dev-ref/xpp-static-classes.md
@@ -1,5 +1,5 @@
 ---
-title: X++ static classes
+title: X++ static class members
 description: This topic describes static classes in X++.
 author: RobinARH
 ms.date: 12/02/2019
@@ -11,7 +11,7 @@ ms.search.validFrom: 2016-02-28
 ms.dyn365.ops.version: AX 7.0.0
 ---
 
-# X++ static classes
+# X++ static class members
 
 [!include [banner](../includes/banner.md)]
 


### PR DESCRIPTION
Static classes are not supported in X++. Proposed fix - change title from "Static classes" to "Static class members"