### PR TITLE
Details on Sales tax codes transformations

### DIFF
--- a/articles/finance/localizations/emea-nor-e-invoices.md
+++ b/articles/finance/localizations/emea-nor-e-invoices.md
@@ -88,7 +88,7 @@ For more information about how to import ER configurations, see [Download Electr
 
 When you generate electronic invoices, the sales tax code rates are analyzed and transformed into [UNCL5305-compliant categories](https://docs.peppol.eu/pracc/catalogue/1.0/codelist/UNCL5305/). The following logic is used:
 
-- For all non-zero tax rates, the **S** category is used.
+- For all non-zero tax rates, the **S** category is used as a default value. You can use **External codes** in **Tax** \> **Sales tax code** to enter an explicite **Value** representing the external code that should be used as the tax compliant category (e.g. H or AA etc).
 - For all zero tax rates, either the **E** category or the **Z** category is used, depending on the reporting code that is configured for tax-free sales.
 
 ### Customer requisition


### PR DESCRIPTION
adding more details after bugs
https://msdyneng.visualstudio.com/FinOps/_workitems/edit/695419
https://msdyneng.visualstudio.com/FinOps/_workitems/edit/667643/
For all non-zero tax rates, the **S** category is used as a default value. You can use **External codes** in **Tax** \> **Sales tax code** to enter an explicite **Value** representing the external code that should be used as the tax compliant category (e.g. H or AA etc).