### PR TITLE
Update certificate-rotation-on-prem.md

### DIFF
--- a/articles/fin-ops-core/dev-itpro/deployment/certificate-rotation-on-prem.md
+++ b/articles/fin-ops-core/dev-itpro/deployment/certificate-rotation-on-prem.md
@@ -115,7 +115,7 @@ You may need to rotate the certificates used by your Dynamics 365 Finance + Oper
 
         ```powershell
         # If remoting, only execute
-        # .\Configure-PreReqs-AllVMs.ps1 -ConfigurationFilePath .\ConfigTemplate.xml -ForcePushLBDScripts
+        # .\Configure-PreReqs-AllVMs.ps1 -MSIFilePath <share folder path of the MSIs> -ConfigurationFilePath .\ConfigTemplate.xml -ForcePushLBDScripts
 
         .\Configure-PreReqs.ps1
         ```


### PR DESCRIPTION
there is a missing argument -MSIfilepath :

# Install prereq software on the VMs.

# If remoting, execute
# .\Configure-PreReqs-AllVMs.ps1 -MSIFilePath <share folder path of the MSIs> -ConfigurationFilePath .\ConfigTemplate.xml

.\Configure-PreReqs.ps1 -MSIFilePath <path of the MSIs>

as we can see on the main set up documentation : 
https://docs.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/deployment/setup-deploy-on-premises-pu41#configurecert