### PR TITLE
Update set-up-procurement-category-hierarchy.md

### DIFF
--- a/articles/supply-chain/procurement/tasks/set-up-procurement-category-hierarchy.md
+++ b/articles/supply-chain/procurement/tasks/set-up-procurement-category-hierarchy.md
@@ -31,7 +31,7 @@ This procedure shows you how to create new nodes in a procurement category hiera
 
 
 ## Add a new procurement category
-1. Go to **Navigation pane > Modules > Procurement and sourcing > Consignment > Procurement categories**.
+1. Go to **Navigation pane > Modules > Procurement and sourcing  > Procurement categories**.
 2. On the Action Pane, select **Edit category hierarchy**. The current procurement category hierarchy is displayed in the left side of the page. You  are about to modify the hierarchy.  
 3. On the Action Pane, select **New category node**. The system selects the top node by default. If you are running this procedure as a task guide, you can click the Unlock button and select another parent node to insert your new node into. Once that is done, lock the task guide again and then click New category node.  
 4. In the **Name** field, type a value.


### PR DESCRIPTION
Procurement categories don't sit under Consignment but just below them in the navigation pane. Hence I've removed the direct Consignment > Procurement categories part of the navigation breadcrumbs.