### PR TITLE
Adding a troubleshooting and FAQ page on the top of the Finance area

### DIFF
--- a/articles/finance/TOC.yml
+++ b/articles/finance/TOC.yml
@@ -202,6 +202,8 @@
           href: ../fin-ops-core/dev-itpro/lifecycle-services/move-on-prem-to-cloud.md?context=/dynamics365/context/finance 
         - name: Multiple LCS projects and production environments on one Azure AD tenant
           href: ../fin-ops-core/fin-ops/get-started/implement-multiple-projects-aad-tenant.md?context=/dynamics365/context/finance    
+    - name: Troubleshooting and FAQs
+      href: Finance-troubleshooting.md
     - name: Accounts payable
       items:
       - name: Accounts payable home page

--- a/articles/finance/finance-troubleshooting.md
+++ b/articles/finance/finance-troubleshooting.md
@@ -27,17 +27,14 @@ These articles explain how to determine, diagnose, and fix issues that you might
 
 Additionally the following troubleshooting articles are integrated into the finance product documentation These articles documents how to troubleshoot a specific topic or subject within the finance area.
 
+Accounts Payable
+
+- [Invoice automation exception processing](accounts-payable/vendor-invoice-automation.md##Exception-processing)
+
 Budgeting
 
 - [Position budgeting troubleshooting](budgeting/position-budgeting-set-up-issues.md)
 
-Finance Insights
-
-- [Troubleshoot Finance insights setup issues](finance-insights/finance-insights-troubleshooting-faq.md)
-
-Accounts Payable
-
-- [Invoice automation exception processing](accounts-payable/vendor-invoice-automation.md##Exception-processing)
 
 Cash and bank management
 
@@ -55,6 +52,10 @@ General Ledger
 - [How do I set up balancing financial dimensions?](general-ledger/set-up-balance-dimensions.md)
 - [Open financial journal templates in Office](general-ledger/open-fincl-jrnls-in-office.md)
 - [Default financial dimensions on financial journals](general-ledger/dimension-default-values.md)
+
+Finance Insights
+
+- [Troubleshoot Finance insights setup issues](finance-insights/finance-insights-troubleshooting-faq.md)
 
 Financial Reporting
 

--- a/articles/finance/finance-troubleshooting.md
+++ b/articles/finance/finance-troubleshooting.md
@@ -1,0 +1,96 @@
+---
+title: Finance troubleshooting and FAQs
+description: This article provides links to troubleshooting resources and frequently asked question articles for Dynamics 365 Finance
+author: Livbjerg
+ms.date: 02/24/2023
+ms.topic: article
+ms.search.form:
+audience: Application User
+ms.reviewer: EPegors
+ms.search.region: Global
+ms.author: Livbjerg
+ms.search.validFrom: 2023-02-28
+ms.dyn365.ops.version: 10.0.28
+---
+
+# Finance Troubleshooting and FAQs
+
+[!include [banner](../includes/banner.md)]
+
+## Troubleshooting articles
+
+For a collection of troubleshooting articles grouped by topic, please see the following site provided by Microsoft Support:
+
+- [Microsoft Dynamics 365 Finance troubleshooting](/troubleshoot/dynamics-365/finance/welcome-finance)
+
+These articles explain how to determine, diagnose, and fix issues that you might encounter when you use Finance. The articles are organized by feature area and each article focuses on a specific issue and how to solve it.
+
+Additionally the following troubleshooting articles are integrated into the finance product documentation These articles documents how to troubleshoot a specific topic or subject within the finance area.
+
+Budgeting
+
+- [Position budgeting troubleshooting](budgeting/position-budgeting-set-up-issues.md)
+
+Finance Insights
+
+- [Troubleshoot Finance insights setup issues](finance-insights/finance-insights-troubleshooting-faq.md)
+
+Accounts Payable
+
+- [Invoice automation exception processing](accounts-payable/vendor-invoice-automation.md##Exception-processing)
+
+Cash and bank management
+
+- [Troubleshoot cash flow forecasting setup](cash-bank-management/cash-flow-forecasting-tsg.md)
+- [Resolve issues with transactions that can't be settled](cash-bank-management/settlement-overview.md##Resolve-issues-with-transactions-that-can't-be-settled)
+
+General Ledger
+
+- [Journal posting failure because of imbalance](general-ledger/posting-fail-imbalance.md)
+- [Why can't I reverse this transaction?](general-ledger/cant-reverse-transctns.md)
+- [Change the accounting or reporting currency](add-change-acctg-rprtg-crrncy.md)
+- [Change or reassign a ledger calendar](general-ledger/change-mdfy-clndr-to-ledger.md)
+- [Reverse settings on journals and lines](general-ledger/rvrs-settgs-on-jrnls-lines.md)
+- [Year-end close missing opening balances](general-ledger/yec-mssng-open-blnces.md)
+- [How do I set up balancing financial dimensions?](general-ledger/set-up-balance-dimensions.md)
+- [Open financial journal templates in Office](general-ledger/open-fincl-jrnls-in-office.md)
+- [Default financial dimensions on financial journals](general-ledger/dimension-default-values.md)
+
+Financial Reporting
+
+- [Troubleshooting issues opening Report Designer](general-ledger/financial-reporting-getting-started.md#troubleshooting-issues-opening-report-designer)
+- [Troubleshoot report designer issues with Event viewer](general-ledger/financial-reporting-getting-started.md#troubleshoot-report-designer-issues-with-event-viewer)
+- [Troubleshoot issues connecting to Financial reporting](general-ledger/financial-reporting-getting-started.md#troubleshoot-issues-connecting-to-financial-reporting)
+- [Troubleshoot the Office integration](../fin-ops-core/dev-itpro/office-integration/office-integration-troubleshooting.md?context=/dynamics365/context/finance)
+
+## Frequently asked questions
+
+Collections of frequently asked questions (FAQs) are integrated into the Finance documentation. Each of these articles includes multiple FAQs for a specific feature topic or area.
+
+The following FAQ articles discuss issues specific to Finance:
+
+- [One voucher FAQ](general-ledger/one-voucher-faq.md)
+- [Year-end activities FAQ](general-ledger/faq-year-end-activities.md)
+- [Consolidation and elimination FAQ](budgeting/consolidation-elimination-overview.md)
+- [Financial Reporting Data mart resets FAQ](../fin-ops-core/dev-itpro/analytics/when-to-reset-data-mart.md?context=/dynamics365/context/finance)
+- [Financial reporting FAQ](general-ledger/financial-reporting-faq.md)
+
+The following FAQ articles discuss issues related to the platform shared by all finance and operations apps, including Finance:
+
+- [Address books FAQ](../fin-ops-core/fin-ops/organization-administration/qa-address-books.md?toc=/dynamics365/supply-chain/toc.json)
+- [Client FAQ](../fin-ops-core/fin-ops/get-started/client-faq.md?toc=/dynamics365/supply-chain/toc.json)
+- [Electronic Invoicing FAQ](../finance/localizations/e-invoicing-faq.md?toc=/dynamics365/supply-chain/toc.json)
+- [Invoice capture FAQ](../fin-ops-core/fin-ops/imp-lifecycle/go-live-faq.md?toc=/dynamics365/supply-chain/toc.json)
+- [One Version service updates FAQ](../fin-ops-core/fin-ops/get-started/one-version.md?toc=/dynamics365/supply-chain/toc.json)
+- [Open in Excel experiences FAQ](../fin-ops-core/dev-itpro/office-integration/office-integration-edit-excel.md?toc=/dynamics365/supply-chain/toc.json)
+- [Subscriptions, LCS projects, and Azure Active Directory tenants FAQ](../fin-ops-core/fin-ops/get-started/subscription-overview.md?toc=/dynamics365/supply-chain/toc.json)
+- [Workflow FAQ](../fin-ops-core/fin-ops/organization-administration/workflow-FAQ.md?toc=/dynamics365/supply-chain/toc.json)
+
+## Other support resources
+
+The following Microsoft support and community resources are also available, where you can discuss and solve issues, browse Blogs, request features, and more:
+
+- [Microsoft Dynamics 365 Blog](https://cloudblogs.microsoft.com/dynamics365/?source=dynamicsaxscm)
+- [Dynamics 365 Community](https://community.dynamics.com/)
+- [Finance ideas portal](https://experience.dynamics.com/ideas/categories/?forum=16691718-61e2-e611-8101-5065f38b21f1&forumName=Dynamics%20365%20Finance)
+- [Dynamics 365 support](https://dynamics-int.microsoft.com/support/)


### PR DESCRIPTION
I added this request to add a structure similar to the SCM area where the Troublesheeting and FAQ page sits right after get-started. 
This page contains links to the troubleshooting page on the support web-site as well a links to troubleshooting areas under the finance area.
It also links to the FAQ pages in the fonance area. 
