### PR TITLE
DataManagementAPI: Fix error in retrieving blob url

### DIFF
--- a/articles/fin-ops-core/dev-itpro/data-entities/data-management-api.md
+++ b/articles/fin-ops-core/dev-itpro/data-entities/data-management-api.md
@@ -200,9 +200,9 @@ HTTP/1.1 200 OK
 | string errorkeysfileurl | The URL of the error keys file, if the file is available. If the error file is still being generated, or if no errors exist, the method returns an empty string. |
 
 
-### GetAzureWritableUrl
+### GetAzureWriteUrl
 
-The **GetAzureWritableUrl** API is used to get a writable blob URL. The method includes a shared access signature (SAS) token that is embedded in the URL. You can use this method to upload a data package to the Azure Blob storage container. For on-premises deployments, this API will still return the URL that has been abstracted to local storage.
+The **GetAzureWriteUrl** API is used to get a writable blob URL. The method includes a shared access signature (SAS) token that is embedded in the URL. You can use this method to upload a data package to the Azure Blob storage container. For on-premises deployments, this API will still return the URL that has been abstracted to local storage.
 
 > [!NOTE]
 > An SAS is valid only during an expiry time window. Any request that is issued after the window has passed returns an error. For more information, see [Using shared access signatures (SAS)](/azure/storage/common/storage-dotnet-shared-access-signature-part-1).


### PR DESCRIPTION
API action name is called [`GetAzureWriteUrl`](https://github.com/MicrosoftDocs/dynamics-365-unified-operations-public/blob/98785b224d68b5c76ad2e99598d2483da87c7aa0/articles/fin-ops-core/dev-itpro/data-entities/data-management-api.md?plain=1#L211) and not ~~`GetAzureWritableUrl`~~.