### PR TITLE
Add missing "t" in data-management-api.md

### DIFF
--- a/articles/fin-ops-core/dev-itpro/data-entities/data-management-api.md
+++ b/articles/fin-ops-core/dev-itpro/data-entities/data-management-api.md
@@ -243,7 +243,7 @@ HTTP/1.1 200 OK
 
 The **ImportFromPackage** API is used to initiate an import from the data package that is uploaded to the Blob storage that is associated with your implementation. For on-premises deployments, the import will be initiated from the local storage that the file was uploaded previously to.
 
-There is an async version of this API **ImportFromPackageAsync**. The specifications are the same. I will be required to capture the execution id returned and the later call the **GetExecutionSummaryStatus** API to determine when the execution has completed.   
+There is an async version of this API **ImportFromPackageAsync**. The specifications are the same. It will be required to capture the execution id returned and the later call the **GetExecutionSummaryStatus** API to determine when the execution has completed.   
 
 > [!NOTE]
 > The **ImportFromPackage** API supports composite entities. However, the limitation is that there can be only one composite entity in a package.
@@ -351,7 +351,7 @@ HTTP/1.1 200 OK
 
 The **ExportToPackage** API is used to initiate an export of a data package. This API is applicable to both cloud deployments and on-premises deployments.
 
-There is an async version of this API **ExportToPackageAsync**. The specifications are the same. I will be required to capture the execution id returned and the later call the **GetExecutionSummaryStatus** API to determine when the execution has completed. 
+There is an async version of this API **ExportToPackageAsync**. The specifications are the same. It will be required to capture the execution id returned and the later call the **GetExecutionSummaryStatus** API to determine when the execution has completed. 
 
 - The export data project must be created before you call this API. If the project doesn't exist, a call to the API returns an error.
 - If change tracking has been turned on, only records that have been created or updated since the last run are exported. (In other words, only the delta is returned.)


### PR DESCRIPTION
Third line should be start with "**It**". But it is starting with "**I**"

**Incorrect Paragraph:**
There is an async version of this API ImportFromPackagePreviewAsync. The specifications are the same. `I will be required to capture the execution id returned and the later call the GetExecutionSummaryStatus API to determine when the execution has completed.`


**Correct Paragraph:**
There is an async version of this API ImportFromPackagePreviewAsync. The specifications are the same. `It will be required to capture the execution id returned and the later call the GetExecutionSummaryStatus API to determine when the execution has completed.`