### PR TITLE
missing space in creating of guid object in xpp-data-primitive.md

### DIFF
--- a/articles/fin-ops-core/dev-itpro/dev-ref/xpp-data-primitive.md
+++ b/articles/fin-ops-core/dev-itpro/dev-ref/xpp-data-primitive.md
@@ -197,7 +197,7 @@ static void GuidRoundTripJob(Args _args)
     str string3;
 
     // Convert a guid to a string, and back to a guid.
-    guid2 = newGuid();
+    guid2 = new Guid();
     info(strFmt("Info_a1:  guid2 == %1", guid2));
     string3 = guid2str(guid2);
     info(strFmt("Info_a2:  string3 == %1", string3));


### PR DESCRIPTION
Missing space between newGuid()

![image](https://github.com/MicrosoftDocs/dynamics-365-unified-operations-public/assets/89014529/26a081e0-f912-47b5-8ec9-c02ab9906bca)
