### PR TITLE
Update administrator account name to localadmin for the F&O VHD

### DIFF
--- a/articles/fin-ops-core/dev-itpro/dev-tools/access-instances.md
+++ b/articles/fin-ops-core/dev-itpro/dev-tools/access-instances.md
@@ -131,7 +131,7 @@ Follow these steps to run the VM from Hyper-V Manager.
 3. Select the **Ctrl+Alt+Delete** button on the toolbar. The VM receives most keyboard commands, but Ctrl+Alt+Delete isn't one of them. Therefore, you must use the button or a menu command.
 4. Sign in to the VM by using the following credentials:
 
-    - User name: **Administrator**
+    - User name: **localadmin**
     - Password: <strong>pass@word1</strong>
 
     > [!TIP]

--- a/articles/fin-ops-core/dev-itpro/dev-tools/vhd-setup.md
+++ b/articles/fin-ops-core/dev-itpro/dev-tools/vhd-setup.md
@@ -33,7 +33,7 @@ Once created, make note of the **Application (client) ID**.
 
 ## Run the setup script
 
-After you sign in with the **Administrator** account, right-click the desktop shortcut **Generate Self-Signed Certificates**, and select **Run as administrator**. When the script prompts for the application ID, provide the **Application (client) ID** created in Azure Active Directory.
+After you sign in with the **localadmin** account, right-click the desktop shortcut **Generate Self-Signed Certificates**, and select **Run as administrator**. When the script prompts for the application ID, provide the **Application (client) ID** created in Azure Active Directory.
 
 When the script finishes, the environment is ready for use. At this time, you can run the Admin Provisioning tool to set the administrator account, permissions, and tenant. Make sure that the email provided is for the Azure Active Directory tenant in which the application registration was created.
 


### PR DESCRIPTION
The F&O VHD has switched the default admin account from **Administrator** to **localadmin**. This updates the documentation to match.