### PR TITLE
Update recurring-integrations.md

### DIFF
--- a/articles/fin-ops-core/dev-itpro/data-entities/recurring-integrations.md
+++ b/articles/fin-ops-core/dev-itpro/data-entities/recurring-integrations.md
@@ -153,7 +153,7 @@ POST https://usncax1aos.cloud.onebox.dynamics.com/en/api/connector/ack/%7BC03BB9
 > Until a message is successfully acknowledged, the same message will become available to dequeue every 30 minutes. In cases when a message is being dequeued more than one time, the dequeue response will send the last dequeued date time. This will be blank for the first dequeue of a message. It is important to ensure that a message is successfully acknowledged to prevent a repeated download of the same message. When an acknowledgement fails, having re-try logic to acknowledge the failure is recommended.
 
 ### API for getting message status
-The API to get the status of a message is available as of hotfix KB 4058074 for Platform update 12. This API is particularly useful in import scenarios to determine if a message has been successfully processed. A message is created when the enqueue process is completed. If the message returns a failed status, you can set your integration app to retry or take another action.
+The API to get the status of a message is available as of hotfix KB 4058074 for Platform update 12. This API is particularly useful in import scenarios to determine if a message has been successfully processed. A message is created when the [enqueue process](#api-for-import-enqueue) is completed. If the message returns a failed status, you can set your integration app to retry or take another action.
 
 **Example**
 


### PR DESCRIPTION
Adding internal link to "API for import (enqueue)" to clarify the source message, per issue https://github.com/MicrosoftDocs/dynamics-365-unified-operations-public/issues/4664.

The "API for getting message status" section mentions the "enqueue process" which upon completion generates a message containing the status. (Generating this message is described in the section "API for import (enqueue)").
The "...message status" text implies the user should use the message GUID mentioned in the "enqueue" section as the "<string>" input in the message status sample code.