### PR TITLE
Change the documentation to reflect the product change from using one warehouse worker for all MHAX inbound queue messages to the user mappings between system users and warehouse workers.

### DIFF
--- a/articles/supply-chain/warehousing/mhax.md
+++ b/articles/supply-chain/warehousing/mhax.md
@@ -51,7 +51,7 @@ You must set a few general parameters on the **Material handling equipment inter
 1. Go to **Material handling equipment interface \> Setup \> Material handling equipment interface parameters**.
 2. On the **General** tab, set the following fields:
 
-    - **User ID** – Select a worker. This worker will be used to run all work operations (picks and puts) that are processed through the inbound queue.
+    - **User mappings** – Map the system users that will be used to call the inbound queue service to warehouse workers. The selected worker will be used to run all work operations (picks and puts) that are processed through the inbound queue. The work operations will be performed in the default warehouse of the worker.
     - **Enable inbound message ID** – When this option is set to *Yes*, if a duplicate inbound message ID is received, the message will be rejected, and an error message will state that the message already exists. When this option is set to *No*, duplicate inbound message IDs will be allowed.
     - **Enable manual inbound message creation** – When this option is set to *Yes*, you can simulate inbound messages by creating a record directly from the **Inbound queue** page.
 


### PR DESCRIPTION
In the product, we changed the configuration of MHAX from using a single user ID to having a user mapping table. Made a simple change in the documentation to reflect this change.