### PR TITLE
Fix Bug -  CustTable Insert

### DIFF
--- a/articles/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement.md
+++ b/articles/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement.md
@@ -45,7 +45,7 @@ The following example inserts a new record into the CustTable table. The **Accou
 ```xpp
 ttsBegin;
     CustTable custTable;
-    select forUpdate custTable;
+    custTable.initValue();
     custTable.AccountNum = '2000';
     custTable.CustGroup = '1';
     custTable.insert();


### PR DESCRIPTION
In prev. version, some existing record will be selected from CustTable, AccountNum  and CustGroup fields will be overridden, and new record will be created, but other fields can have some values from an existing record selected before.