### PR TITLE
Incorrectly listed as C# instead of XML.

### DIFF
--- a/articles/commerce/dev-itpro/cdx-extensibility.md
+++ b/articles/commerce/dev-itpro/cdx-extensibility.md
@@ -282,7 +282,7 @@ From the Retail SDK folder, open and run the SQL Server **ContosoRetailExtension
 
 The sample CDX resource file in the Retail SDK contains additional customizations. However, for our example of RetailTransactionTable extension, the section in the following code is the only section that is required to pull data from the channel side back to HQ.
 
-```csharp
+```xml
 <RetailCdxSeedData Name="AX7" ChannelDBSchema="ext" ChannelDBMajorVersion="7">
     <Subjobs>
         <!--Adding additional columns to (existing) RetailTransactionTable and wants to pull it back to HQ.For upload subjobs, set the OverrideTarget property to  "false", as ilustrated below. This will tell CDX to use the table defined by TargetTableName and TargetTableSchema as extension table on this subjob.-->


### PR DESCRIPTION
The file had an issue where the language name was incorrectly listed as C# instead of XML.