### PR TITLE
Update emea-fra-VAT-declaration-preview-France.md

### DIFF
--- a/articles/finance/localizations/france/emea-fra-VAT-declaration-preview-France.md
+++ b/articles/finance/localizations/france/emea-fra-VAT-declaration-preview-France.md
@@ -232,9 +232,6 @@ For more information about how to configure reverse charge VAT, see [Reverse cha
 
 To automatically generate a VAT declaration preview report in Microsoft Excel, associate sales tax codes in the application and lookup results in the ER configuration.
 
-> [!NOTE]
-> We recommend that you enable the feature, **Use application specific parameters from previous versions of ER formats** in the **Feature management** workspace. When this feature is enabled, parameters that are configured for the earlier version of an ER format automatically become applicable for the later version of the same format. If this feature is not enabled, you must configure application-specific parameters explicitly for each format version. The **Use application specific parameters from previous versions of ER formats** feature is available in the **Feature management** workspace starting in Finance version 10.0.23. For more information about how to set up the parameters of an ER format for each legal entity, see [Set up the parameters of an ER format per legal entity](../../../fin-ops-core/dev-itpro/analytics/er-app-specific-parameters-set-up.md).
-
 #### Set up operations
 
 Follow these steps to define which sales tax codes generate which boxes in section A, "AMOUNT OF OPERATIONS CARRIED OUT."


### PR DESCRIPTION
The Note about the feature, Use application specific parameters from previous versions of ER formats, is not relevant any longer as the feature does not exists any longer in version 10.0.40 (10.0.1935.69) with the name: "Use application specific parameters from previous versions of ER formats"

NB that the Note is exists in a lot of articles in the docs. I have just suggested the change for France but I think the same change should be done everywhere the note exists.