### PR TITLE
Update apac-aus-business-activity-statement.md

### DIFF
--- a/articles/finance/localizations/australia/apac-aus-business-activity-statement.md
+++ b/articles/finance/localizations/australia/apac-aus-business-activity-statement.md
@@ -843,7 +843,7 @@ For a list of fringe benefit reason codes, see [FBT reason codes](https://www.at
 <p>Other acquisitions</p>
 </td>
 <td>
-<p>[11] + G13 + G14 + G15</p>
+<p>[11] + [13] + [14] + [15]</p>
 </td>
 <td>
 <p>G11</p>


### PR DESCRIPTION
Updated calculation for G11. Previously was [11] + G13 + G14 + G15. It should just be [11] + [13] + [14] + [15]. 
The other part of G13, G14 and G15 respectively [1013], [1014] and [1015] are already included as part of G10 so it should not be included again as part of G11.
