### PR TITLE
Update data-import-export-job.md for parallel task configuration

### DIFF
--- a/articles/fin-ops-core/fin-ops/data-entities/data-import-export-job.md
+++ b/articles/fin-ops-core/fin-ops/data-entities/data-import-export-job.md
@@ -174,6 +174,9 @@ To speed up the import of data, parallel processing of importing a file can be e
     - In the **Import threshold record count** field, enter the threshold record count for import. This determines the record count to be processed by a thread. If a file has 10K records, a record count of 2500 with a task count of four means each thread processes 2500 records.
     - In the **Import task count** field, enter the count of import tasks. The count must not exceed the max batch threads allocated for batch processing in **System administration \>Server configuration**.
 
+> [!NOTE]
+> Adding too many parallel tasks will cause the underlying infrastructure to use the resource capacity to 100% and impact the environment performance and other executions. It is suggested to understand the resource capacity of the environment and consumption based on the parallel import tasks configured and limit the number of tasks.   
+
 ## Job history cleanup 
 By default, job history entries and related staging table data that are older than 90 days are automatically deleted. The job history cleanup functionality in data management can be used to configure periodic cleanup of the execution history with a lower retention period than this default. This functionality replaces the previous staging table cleanup functionality, which is now deprecated. The following tables are cleaned up by the cleanup process.
 


### PR DESCRIPTION
Adding the note on parallel import task configuration. Adding too many tasks will cause the resource capacity usage to hit 100%.