### PR TITLE
Fix typo in toc.yml

### DIFF
--- a/articles/supply-chain/toc.yml
+++ b/articles/supply-chain/toc.yml
@@ -2935,7 +2935,7 @@
             href: production-control/tasks/remove-kanban-job-schedule.md
           - name: Revert kanban job status
             href: production-control/tasks/revert-kanban-job-status.md
-          - name: Schedule kanban jobs)
+          - name: Schedule kanban jobs
             href: production-control/tasks/schedule-kanban-jobs.md
           - name: Transfer materials with kanban jobs
             href: production-control/tasks/transfer-materials-kanban-jobs.md


### PR DESCRIPTION
Removed unnecessary ')' from 'Schedule kanban jobs' in toc.yml