### PR TITLE
Update data-entity-computed-columns-virtual-fields.md

### DIFF
--- a/articles/fin-ops-core/dev-itpro/data-entities/data-entity-computed-columns-virtual-fields.md
+++ b/articles/fin-ops-core/dev-itpro/data-entities/data-entity-computed-columns-virtual-fields.md
@@ -107,11 +107,8 @@ In this example, you add a computed field to the **FMCustomerEntity** entity. Fo
 6. Go to **FMCustomerEntity** &gt; **Methods**. Right-click the **Methods** node, and then click **New**. Ensure that the method name matches the **DataEntityView Method** property value of the unmapped computed field.
 7. Paste the following X++ code into the method. The method returns the combined and formatted **NameAndAddress** value.
 
-    > [!NOTE]
-    > The **server** keyword is required.
-
     ```xpp
-    private static server str formatNameAndAddress()   // X++
+    private static str formatNameAndAddress()   // X++
     {
         DataEntityName      dataEntityName= tablestr(FMCustomerEntity);
         List                fieldList = new List(types::String);


### PR DESCRIPTION
Removed the requirement of using the **server** keyword for computed fields. As all X++ code is run on the server the usage of server and client keywords is no longer necessary.