### PR TITLE
Update adyen-connector-troubleshoot.md

### DIFF
--- a/articles/commerce/dev-itpro/adyen-connector-troubleshoot.md
+++ b/articles/commerce/dev-itpro/adyen-connector-troubleshoot.md
@@ -26,7 +26,7 @@ This article provides troubleshooting guidance for common issues related to the 
 
 For all general issues, you should always consult the Store Commerce app or IIS Hardware Station event logs first. You can find these logs found under the following nodes in the Microsoft Windows event log:
 
-- Application and Services Logs \> Microsoft \> Dynamics \> Commerce-ModernPOS
+- Windows Logs \> Filter Current Log with Event sources set as 'Microsoft Dynamics - Store Commerce' 
 - Application and Services Logs \> Microsoft \> Dynamics \> Commerce-Hardware Station
 
 ### Failing payment transactions


### PR DESCRIPTION
The current doc navigates us to old location and I've updated the event logs location for store commerce as from version 10.0.32+ store commerce logs are now logged under Windows logs with the event source as 'Microsoft Dynamics - Store Commerce'