### PR TITLE
Fix typo

### DIFF
--- a/articles/commerce/dev-itpro/chat-module-pva.md
+++ b/articles/commerce/dev-itpro/chat-module-pva.md
@@ -45,8 +45,8 @@ To find the bot ID of a Power Virtual Agent in the Power Virtual Agents web app,
 1. In the left navigation menu, select **Settings \> Channels**.
 1. Select **Mobile app**.
 1. In the **Mobile app** flyout menu, under **Token Endpoint**, select **Copy** to copy the token endpoint URL.
-1. Open a new browser tab and navigate to the **Token Endpoint**. A JSON result displays. Copy the value of the **token** property. The value is a JWT token.
-1. Decode the JWT token. In the decoded result, the **bot ID** is found in the **bot** field.
+1. Open a new browser tab and navigate to the **Token Endpoint**. A JSON result displays. Copy the value of the **token** property. The value is a JWT.
+1. Decode the JWT. In the decoded result, the **bot ID** is found in the **bot** field.
 
 :::image type="content" source="../media/chat-module-pva-botid.png" alt-text="Find bot ID of a Power Virtual Agent":::
 

--- a/articles/fin-ops-core/dev-itpro/deployment/troubleshoot-on-prem.md
+++ b/articles/fin-ops-core/dev-itpro/deployment/troubleshoot-on-prem.md
@@ -957,7 +957,7 @@ After you have the network log, you can analyze the claims that are returned to 
     > ![Payload example.](media/NetworkLogPayloadOnpremADFS.png)
 
 1. Go to [JWT Decoder](https://jwt.ms).
-1. Paste the value of the **id_token** parameter into the **JWT Token** field. The value is automatically decoded.
+1. Paste the value of the **id_token** parameter into the **JWT** field. The value is automatically decoded.
 1. Review the results in the **Decoded Token and Claims** section, and follow these steps:
 
     - Make sure that the **upn** value matches the user name.


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT Token/JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT Token/JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.