### PR TITLE
Remove reference to unavailable feature "Disable expected receipts from quality orders that sample blocked inventory"

### DIFF
--- a/articles/supply-chain/inventory/inventory-blocking.md
+++ b/articles/supply-chain/inventory/inventory-blocking.md
@@ -84,12 +84,6 @@ When **Reserve ordered items** is disabled, the expected receipts can't be reser
 
 Note the difference in transaction status and dimensions between the two cases. For this reason, we recommend enabling the **Reserve ordered items** option.
 
-## Disable expected receipts from quality orders that sample blocked inventory
-
-To simplify the inventory transactions when quality orders that sample inventory are blocked as a consequence of inventory status, the system provides a feature that disables expected receipts from such quality orders. Because the expected receipt is immediately blocked by inventory status blocking, there's no reduction of on-hand inventory because of this change.
-
-To use this feature, it must be turned on for your system. As of Supply Chain Management version 10.0.29, it's turned on by default. As of Supply Chain Management version 10.0.32, this feature is mandatory and can't be turned off. If you're running a version older than 10.0.32, then admins can turn this functionality on or off by searching for the *Disable expected receipts from quality orders that sample blocked inventory* feature in the [**Feature management** workspace](../../fin-ops-core/fin-ops/get-started/feature-management/feature-management-overview.md).
-
 ## Related information
 
 - [Create and maintain an inventory blocking](tasks/create-maintain-inventory-blocking.md)


### PR DESCRIPTION
The feature "Disable expected receipts from quality orders that sample blocked inventory" has been mandatory for some time, and is no longer available as of the latest version 10.0.43. It is causing a bit of confusion, as shown in this community post https://community.dynamics.com/forums/thread/details/?threadid=2f7e43d8-ea28-f011-8c4d-7c1e52643bb6

It should therefore be removed from the documentation.

Screenshot of latest version, with feature unavailable:
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/b0790c29-10de-4a7c-8473-4b3dd6e93be5" />

Missing references to label text in F&O code:
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/4f0cf4f2-a57f-45a3-9ce8-cb6ecfbc33f0" />
