### PR TITLE
Deprecate functionality "Create new identity" on Commerce workers

### DIFF
--- a/articles/commerce/dev-itpro/set-up-activation-accounts-validate-devices-hq.md
+++ b/articles/commerce/dev-itpro/set-up-activation-accounts-validate-devices-hq.md
@@ -33,25 +33,15 @@ This procedure should be completed before you activate Store Commerce for web.
     - UPN
     - External identifier
 
-4. You can update the **External identity** fields by using an existing Microsoft Entra account or creating a new Microsoft Entra account. To update the fields, access the **External identity** options from the **Commerce** main menu (**Commerce \> Associate existing identity \> Commerce \> Create new identity**).
-5. To use an existing Microsoft Entra account, select **Commerce \> Associate existing identity**. In the slider, select the Microsoft Entra account that has the correct name, and then select **OK**. The Microsoft Entra account that is associated with that name and alias is the user's activation account for the Store Commerce app.
-6. Complete and save the changes on the **Workers** page, and then refresh the page. The section that contains external identity information should be updated with the new information. The mapped Microsoft Entra account is now your activation account for the Store Commerce app and Store Commerce for web. This account is mapped to a worker for the required POS permissions. You can use this Microsoft Entra account for Store Commerce app and Store Commerce for web activation.
-7. The Create external identity feature creates a new Microsoft Entra account for you by using the alias that you enter. To update the fields, access the **External identity** options from the **Commerce** main menu (**Commerce \> Create new identity**).
-8. You can either manually enter the alias to generate or use the **Reset to default** button. Then manually enter a strong password, and select **OK**.
-9. If the worker is created successfully, you receive a message on the **Workers** page. The mapped Microsoft Entra account is now the user's activation account for the Store Commerce app and Store Commerce for web. This account is mapped to a worker for the required POS permissions. You can use this Microsoft Entra account for Store Commerce app or Store Commerce for web activation.
+4. To use an existing Microsoft Entra account, select **Commerce \> Associate existing identity**. In the slider, select the Microsoft Entra account that has the correct name, and then select **OK**. The Microsoft Entra account that is associated with that name and alias is the user's activation account for the Store Commerce app.
+5. Complete and save the changes on the **Workers** page, and then refresh the page. The section that contains external identity information should be updated with the new information. The mapped Microsoft Entra account is now your activation account for the Store Commerce app and Store Commerce for web. This account is mapped to a worker for the required POS permissions. You can use this Microsoft Entra account for Store Commerce app and Store Commerce for web activation.
+6. You can either manually enter the alias to generate or use the **Reset to default** button. Then manually enter a strong password, and select **OK**.
+7. If the worker is created successfully, you receive a message on the **Workers** page. The mapped Microsoft Entra account is now the user's activation account for the Store Commerce app and Store Commerce for web. This account is mapped to a worker for the required POS permissions. You can use this Microsoft Entra account for Store Commerce app or Store Commerce for web activation.
 
 ## Setting up device activation accounts for multiple workers
 
-You can set up activation accounts for multiple workers in bulk. However, this functionality is supported only if you're creating new external identities, not if you're associating identities.
-
-1. In the workers form, select the list of workers to set the activation account for.
-2. Select **Commerce \> Create external identity** to update the fields. Any Microsoft Entra accounts that are associated with the workers appear in this pane.
-
-    > [!NOTE]
-    > These accounts aren't device activation accounts until you map them by using the external identity flow options.
-
-3. If you want to use the existing Microsoft Entra accounts as activation accounts, you can't map them in bulk. Cancel the selection of those workers, and then map them individually by using **Use existing external identity**.
-4. To create new Microsoft Entra accounts and associate them with the workers, so that they can be used as activation accounts, update the **Alias** and **Password** fields, and then select **OK**. In the main worker form, you receive a message as activation accounts are created for each worker.
+> [!WARNING]
+> Due to security compliance, the feature **Commerce \> Create new identity** was deprecated in release 10.0.44 (PU68). New users should be created directly in Microsoft Entra ID. This also impacted the functionality to create multiple users and associate them in bulk that was previously supported.
 
 ## Run the Validate Devices for activation check at headquarters
 

--- a/articles/commerce/dev-itpro/set-up-activation-accounts-validate-devices-hq.md
+++ b/articles/commerce/dev-itpro/set-up-activation-accounts-validate-devices-hq.md
@@ -18,6 +18,10 @@ ms.search.form: HcmWorker, RetailDeviceActivationValidation, RetailPositionPosPe
 # Manage activation accounts and validate devices
 
 [!include [banner](../includes/banner.md)]
+> [!WARNING]
+> Due to security compliance, the feature **Commerce \> Create new identity** was deprecated in release 10.0.44 (PU68).
+> 
+> New users should be created directly through Microsoft Entra ID's [new user workflow](https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/CreateUser.ReactView).
 
 This article explains how an IT Pro can set up Commerce activation accounts for workers to activate Store Commerce devices.
 
@@ -37,11 +41,6 @@ This procedure should be completed before you activate Store Commerce for web.
 5. Complete and save the changes on the **Workers** page, and then refresh the page. The section that contains external identity information should be updated with the new information. The mapped Microsoft Entra account is now your activation account for the Store Commerce app and Store Commerce for web. This account is mapped to a worker for the required POS permissions. You can use this Microsoft Entra account for Store Commerce app and Store Commerce for web activation.
 6. You can either manually enter the alias to generate or use the **Reset to default** button. Then manually enter a strong password, and select **OK**.
 7. If the worker is created successfully, you receive a message on the **Workers** page. The mapped Microsoft Entra account is now the user's activation account for the Store Commerce app and Store Commerce for web. This account is mapped to a worker for the required POS permissions. You can use this Microsoft Entra account for Store Commerce app or Store Commerce for web activation.
-
-## Setting up device activation accounts for multiple workers
-
-> [!WARNING]
-> Due to security compliance, the feature **Commerce \> Create new identity** was deprecated in release 10.0.44 (PU68). New users should be created directly in Microsoft Entra ID. This also impacted the functionality to create multiple users and associate them in bulk that was previously supported.
 
 ## Run the Validate Devices for activation check at headquarters
 

--- a/articles/commerce/get-started/removed-deprecated-features-commerce.md
+++ b/articles/commerce/get-started/removed-deprecated-features-commerce.md
@@ -28,6 +28,19 @@ This list is intended to help you consider these removals and deprecations for y
 > [!NOTE]
 > Detailed information about objects in finance and operations apps can be found in the [Technical reference reports](/dynamics/s-e/). You can compare the different versions of these reports to learn about objects that have changed or been removed in each version of finance and operations apps.
 
+## Features removed or deprecated in the Commerce 10.0.44 release
+
+### Creation of worker new identity in tenant directory
+
+| &nbsp;  | &nbsp; |
+|------------|--------------------|
+| **Reason for deprecation/removal** | Improve platform security by removing Finance and Operations access to the tenant's user directory. |
+| **Replaced by another feature?**   | New users can be created directly in Microsoft Entra ID. |
+| **What do you need to do?**        | <p>In form **Workers**, tab **Commerce**, when the **Create new identity** option is disabled or fail, new identities need to be created directly in Microsoft Entra ID, then associated with the worker through the **Associate existing identity** option.</p>|
+| **Product areas affected**         | Commerce headquarters |
+| **Deployment option**              | All |
+| **Status**                         | <p>The functionality was disabled in release 10.0.44 (PU68) with a deprecation message, but the access to the tenant's user directory will be removed globally and even older releases won't work after July 2025.</p><p>For more information, and for updates about this change, see [Manage activation accounts and validate devices](https://learn.microsoft.com/en-us/dynamics365/commerce/dev-itpro/set-up-activation-accounts-validate-devices-hq).</p> |
+
 ## Features removed or deprecated in the Commerce 10.0.39 release
 
 ### (Italy) Customer information management for Retail POS


### PR DESCRIPTION
Finance and Operations first party application will have the permissions to tenant's user directory removed, so the functionality "Create new identity" will stop working and we are deprecating it. 

Future investment to support to "on-behalf of" the customer's third-party app still being planned.