### PR TITLE
Removed feference to obsolete class SysMessageProcessorToggle

### DIFF
--- a/articles/supply-chain/message-processor/developer/message-processor-develop.md
+++ b/articles/supply-chain/message-processor/developer/message-processor-develop.md
@@ -237,27 +237,6 @@ This example shows how to add a new queue. After the queue is created, you'll be
         {
             return false;
         }
-    
-    }
-    ```
-
-1. Create an extension for the `SysMessageProcessorToggle` class to enable the message processor in the user interface (UI).
-
-    ```xpp
-    [ExtensionOf(classStr(SysMessageProcessorToggle))]
-    final class MySysMessageProcessorToggle_Extension
-    {
-        /// <summary>
-        /// Determines if the toggle is enabled.
-        /// </summary>
-        /// <returns>
-        /// true if the toggle is enabled; otherwise, false.
-        /// </returns>
-        internal boolean isEnabled()
-        {
-            return next isEnabled() || MyFeature::instance().isEnabled();
-        }
-    
     }
     ```
 


### PR DESCRIPTION
The page said that SysMessageProcessorToggle class should be extended, but the class has been made obsolete in 2023. There is a comment saying: "The message processor is now enabled everywhere. This class is no longer used and will be deleted in a future release.".