### PR TITLE
Add real world channel-side calculation example to POS inventory lookup article

### DIFF
--- a/articles/commerce/inventory-aware-product-listing.md
+++ b/articles/commerce/inventory-aware-product-listing.md
@@ -66,4 +66,34 @@ The category and search results page displays products at the product master lev
 
 You can configure the **Inventory settings for product list pages** setting in Commerce site builder to control how the category and search results page displays out-of-stock products. For more information, see [Apply inventory settings](inventory-settings.md).
 
+### Choosing the right out-of-stock display behavior for your channel
+
+The decision to hide out-of-stock products versus moving them to the bottom of a 
+product listing page depends on how your customers behave and how your catalog is 
+structured.
+
+For retailers selling products with strong brand or model loyalty, hiding 
+out-of-stock items entirely is often the more effective approach. When a 
+best-selling model goes out of stock, customers who are attached to that specific 
+product tend to wait for it to return rather than switching to an alternative. 
+Keeping it visible on the listing page reinforces that attachment and draws 
+attention away from models that are actually available. Removing it from the list 
+redirects that browsing traffic toward in-stock alternatives, which keeps sales 
+moving and prevents the listing page from becoming a source of frustration.
+
+Displaying out-of-stock products also risks a negative customer experience. 
+Shoppers who click through to a product detail page only to find it unavailable 
+often leave the site without purchasing anything. In contrast, a listing page that 
+shows only available products gives customers a cleaner path to purchase.
+
+A practical approach for this scenario is to hide out-of-stock products by 
+setting them to draft status when stock is depleted, then reactivating them once 
+inventory is replenished. This keeps the listing page focused on what customers 
+can actually buy, while ensuring that high-demand products return to full 
+visibility as soon as stock is available again.
+
+For products where customers are more flexible about which variant or model they 
+choose, moving out-of-stock items to the bottom of the list may be sufficient, 
+as it preserves catalog visibility without disrupting the shopping experience.
+   
 [!INCLUDE[footer-include](../includes/footer-banner.md)]

--- a/articles/commerce/inventory-buffers-levels.md
+++ b/articles/commerce/inventory-buffers-levels.md
@@ -130,6 +130,35 @@ To configure the response of the product availability APIs, follow these steps:
 1. In the **Store inventory** section, on the **Inventory** tab, in the **Product availability APIs for e-Commerce** field, select a value.
 1. Run the **1110** (**Global configuration**) distribution schedule job to apply the settings to channels.
 
+### Real-world example: Managing oversell risk in multichannel e-commerce
+
+Consider a retailer selling the same product across three channels at the same time: 
+a Shopify storefront, Amazon, and eBay. Physical stock stands at 100 units. Because 
+inventory availability APIs update asynchronously, all three channels display 
+"Available" simultaneously, regardless of orders being placed in real time.
+
+Without an inventory buffer, the following situation can occur. Amazon receives an 
+unexpected bulk order for 90 units. At the same moment, 15 orders come in through 
+Shopify and another 15 through eBay. The system processes all of them against the 
+same 100 units of stock, resulting in 120 committed units and 20 oversold items. 
+The retailer is left canceling orders and managing customer complaints after the fact.
+
+With an inventory buffer in place, this situation is prevented before it starts. 
+Setting a buffer of 15 units means the system exposes only 85 units as available 
+across all channels. When the 90-unit bulk order arrives on Amazon, the customer 
+cannot complete the purchase because the system does not have enough available 
+quantity to fulfill it. The remaining stock stays protected for other channels.
+
+Combining the buffer with inventory level profiles gives retailers further control 
+over what customers see at each stage:
+
+- **In stock**: 16 or more units remaining after the buffer is applied
+- **Low stock**: 1 to 15 units remaining after the buffer is applied
+- **Out of stock**: 0 or fewer units remaining after the buffer is applied
+
+This setup allows the retailer to catch oversell risk at the point of purchase, 
+rather than discovering the problem after orders are already confirmed.
+
 ## Additional resources
 
 [Manage product categories and products](category-management-product-creation.md)

--- a/articles/commerce/inventory-lookup-channel-side-calc.md
+++ b/articles/commerce/inventory-lookup-channel-side-calc.md
@@ -48,4 +48,33 @@ If the channel database doesn't contain transactional data for any of the wareho
 
 The **Order fulfillment** pages of POS also use channel-side calculation to show on-hand inventory for items when an order fulfillment line is selected and a user views the **Details** pane for on-hand inventory for the selected item.
 
+### Real-world example: Reducing oversell risk from offline sales in a multichannel operation
+
+In retail operations that combine physical and online sales, inventory discrepancies 
+often originate from transactions that occur outside the online channel. A common 
+example is a walk-in or phone-based sale that is processed at the store level but 
+not yet reflected in Commerce headquarters due to the synchronization interval of 
+the 1130 job.
+
+Consider a retailer with 10 units of a product in stock. A walk-in customer 
+purchases 3 units, which are recorded in the local POS database. Until the next 
+headquarters sync runs, the central system still shows 10 units available. During 
+this window, an online customer browsing the e-commerce site also sees 10 units 
+and places an order for 8. The result is an oversell of 1 unit, which leads to 
+a canceled order, a customer refund, and potential damage to marketplace rankings 
+if the sale originated from a platform such as Amazon or eBay.
+
+When channel-side calculation is enabled, the local POS transaction is factored 
+into the inventory count immediately, without waiting for headquarters 
+synchronization. The online channel reads from the local channel database and 
+displays 7 units available. The 8-unit order is blocked before it is placed, 
+preventing the oversell entirely.
+
+This approach is particularly valuable for retailers who process manual or 
+offline orders alongside their online channels. When a manual order is created 
+and confirmed, the stock reduction is reflected in the local channel database 
+right away. Online customers see an updated inventory count before the next 
+headquarters sync runs, which keeps stock levels accurate across all customer 
+touchpoints without requiring real-time service calls to headquarters.
+
 [!INCLUDE[footer-include](../includes/footer-banner.md)]


### PR DESCRIPTION
Added a practical multichannel retail scenario demonstrating how channel-side calculation prevents overselling when offline or manual sales occur outside the online channel, before headquarters synchronization runs.