### PR TITLE
Add real-world inventory display and messaging guidance to inventory settings article

### DIFF
--- a/articles/commerce/inventory-aware-product-listing.md
+++ b/articles/commerce/inventory-aware-product-listing.md
@@ -66,4 +66,34 @@ The category and search results page displays products at the product master lev
 
 You can configure the **Inventory settings for product list pages** setting in Commerce site builder to control how the category and search results page displays out-of-stock products. For more information, see [Apply inventory settings](inventory-settings.md).
 
+### Choosing the right out-of-stock display behavior for your channel
+
+The decision to hide out-of-stock products versus moving them to the bottom of a 
+product listing page depends on how your customers behave and how your catalog is 
+structured.
+
+For retailers selling products with strong brand or model loyalty, hiding 
+out-of-stock items entirely is often the more effective approach. When a 
+best-selling model goes out of stock, customers who are attached to that specific 
+product tend to wait for it to return rather than switching to an alternative. 
+Keeping it visible on the listing page reinforces that attachment and draws 
+attention away from models that are actually available. Removing it from the list 
+redirects that browsing traffic toward in-stock alternatives, which keeps sales 
+moving and prevents the listing page from becoming a source of frustration.
+
+Displaying out-of-stock products also risks a negative customer experience. 
+Shoppers who click through to a product detail page only to find it unavailable 
+often leave the site without purchasing anything. In contrast, a listing page that 
+shows only available products gives customers a cleaner path to purchase.
+
+A practical approach for this scenario is to hide out-of-stock products by 
+setting them to draft status when stock is depleted, then reactivating them once 
+inventory is replenished. This keeps the listing page focused on what customers 
+can actually buy, while ensuring that high-demand products return to full 
+visibility as soon as stock is available again.
+
+For products where customers are more flexible about which variant or model they 
+choose, moving out-of-stock items to the bottom of the list may be sufficient, 
+as it preserves catalog visibility without disrupting the shopping experience.
+   
 [!INCLUDE[footer-include](../includes/footer-banner.md)]

--- a/articles/commerce/inventory-buffers-levels.md
+++ b/articles/commerce/inventory-buffers-levels.md
@@ -130,6 +130,35 @@ To configure the response of the product availability APIs, follow these steps:
 1. In the **Store inventory** section, on the **Inventory** tab, in the **Product availability APIs for e-Commerce** field, select a value.
 1. Run the **1110** (**Global configuration**) distribution schedule job to apply the settings to channels.
 
+### Real-world example: Managing oversell risk in multichannel e-commerce
+
+Consider a retailer selling the same product across three channels at the same time: 
+a Shopify storefront, Amazon, and eBay. Physical stock stands at 100 units. Because 
+inventory availability APIs update asynchronously, all three channels display 
+"Available" simultaneously, regardless of orders being placed in real time.
+
+Without an inventory buffer, the following situation can occur. Amazon receives an 
+unexpected bulk order for 90 units. At the same moment, 15 orders come in through 
+Shopify and another 15 through eBay. The system processes all of them against the 
+same 100 units of stock, resulting in 120 committed units and 20 oversold items. 
+The retailer is left canceling orders and managing customer complaints after the fact.
+
+With an inventory buffer in place, this situation is prevented before it starts. 
+Setting a buffer of 15 units means the system exposes only 85 units as available 
+across all channels. When the 90-unit bulk order arrives on Amazon, the customer 
+cannot complete the purchase because the system does not have enough available 
+quantity to fulfill it. The remaining stock stays protected for other channels.
+
+Combining the buffer with inventory level profiles gives retailers further control 
+over what customers see at each stage:
+
+- **In stock**: 16 or more units remaining after the buffer is applied
+- **Low stock**: 1 to 15 units remaining after the buffer is applied
+- **Out of stock**: 0 or fewer units remaining after the buffer is applied
+
+This setup allows the retailer to catch oversell risk at the point of purchase, 
+rather than discovering the problem after orders are already confirmed.
+
 ## Additional resources
 
 [Manage product categories and products](category-management-product-creation.md)

--- a/articles/commerce/inventory-settings.md
+++ b/articles/commerce/inventory-settings.md
@@ -57,6 +57,50 @@ In Commerce, define inventory settings at **Site Settings \> Extensions \> Inven
 > [!IMPORTANT]
 > These settings are available in the Dynamics 365 Commerce 10.0.12 release. If you're updating from an older version of Dynamics 365 Commerce, you must manually update the appsettings.json file. For instructions on updating the appsettings.json file, see [SDK and module library updates](e-commerce-extensibility/sdk-updates.md#update-the-appsettingsjson-file).
 
+### Real-world guidance: Choosing the right inventory display and messaging settings
+
+The optimal combination of inventory display and messaging settings depends on 
+the nature of your products and your restocking cycle, not just your current 
+stock levels.
+
+**Choosing between hiding and moving out-of-stock products**
+
+When a product goes out of stock, the right display behavior depends on whether 
+new stock is expected and how soon. If a restock is imminent, moving the product 
+to the end of the list is the more effective approach. Customers who are 
+interested in that specific product can still find it, add it to their cart, 
+and receive a notification when it becomes available. This also opens the door 
+for direct customer inquiries, which can be converted into reservations or 
+pre-orders. For example, a trade customer who needs 400 units of a building 
+material can be handled outside the standard online flow, with stock reserved 
+manually and the system updated accordingly when the order is confirmed.
+
+However, if no restock is planned, keeping the product visible at the bottom 
+of the list creates a false expectation. Customers who notice it may wait for 
+it to return instead of purchasing available alternatives, which reduces 
+overall conversion. In this case, hiding the product entirely keeps the listing 
+page focused on what can actually be purchased and redirects browsing traffic 
+toward in-stock items.
+
+**Choosing the right inventory range messaging**
+
+Low stock messages such as "Only a few left" can drive urgency and push 
+customers toward faster purchase decisions, but their effectiveness depends 
+entirely on the product category.
+
+For unique or handmade products, where customers understand that stock is 
+limited by nature, a low stock message creates genuine urgency and encourages 
+immediate purchases. For commodity or construction products, where customers 
+expect consistent supply and often need to purchase in large quantities, the 
+same message can have the opposite effect. A buyer who needs 50 units and sees 
+"Only a few left" is more likely to look for a more reliable supplier than to 
+place a partial order. In these categories, displaying a low stock message risks 
+losing the customer entirely rather than accelerating the sale.
+
+Configuring inventory range messages to match your product category and customer 
+expectations, rather than applying a single setting across your entire catalog, 
+leads to more effective outcomes for both conversion and customer trust.
+
 ## Modules that use inventory settings
 
 Buy box, wishlist, store selector, cart, and cart icon modules use inventory settings to show the inventory ranges and messages.


### PR DESCRIPTION
Added practical guidance on choosing between hiding and moving out-of-stock products based on restocking cycle, and on selecting inventory range messages based on product category. Based on real-world multichannel e-commerce experience across platforms including Amazon, eBay, Etsy and Shopify.