### PR TITLE
Add multichannel oversell example to inventory buffers article

### DIFF
--- a/articles/commerce/inventory-buffers-levels.md
+++ b/articles/commerce/inventory-buffers-levels.md
@@ -130,6 +130,22 @@ To configure the response of the product availability APIs, follow these steps:
 1. In the **Store inventory** section, on the **Inventory** tab, in the **Product availability APIs for e-Commerce** field, select a value.
 1. Run the **1110** (**Global configuration**) distribution schedule job to apply the settings to channels.
 
+## Example scenario: Managing oversell risk in multichannel e-commerce
+
+Consider a retailer that sells the same product simultaneously through an e-commerce storefront and two third-party marketplaces. Physical stock stands at 100 units. Because inventory availability data updates asynchronously, all three channels show the product as available, regardless of orders being placed in real time.
+
+Without an inventory buffer, the following situation can occur. One marketplace receives an unexpected bulk order for 90 units. At the same moment, 15 orders come in through the storefront and another 15 through the second marketplace. The system processes all of them against the same 100 units of stock, resulting in 120 committed units and 20 oversold items. The retailer is left canceling orders and managing customer complaints after the fact.
+
+With an inventory buffer in place, this situation is prevented before it starts. Setting a buffer of 15 units means that the system exposes only 85 units as available across all channels. When the 90-unit bulk order arrives, the customer can't complete the purchase, because the system doesn't have enough available quantity to fulfill it. The remaining stock stays protected for the other channels.
+
+Combining the buffer with inventory level profiles gives retailers further control over what customers see at each stage:
+
+- **In stock** – 16 or more units remaining after the buffer is applied.
+- **Low stock** – 1 to 15 units remaining after the buffer is applied.
+- **Out of stock** – 0 or fewer units remaining after the buffer is applied.
+
+This setup lets the retailer catch oversell risk at the point of purchase, rather than discovering the problem after orders are already confirmed.
+
 ## Additional resources
 
 [Manage product categories and products](category-management-product-creation.md)


### PR DESCRIPTION
This PR adds an example scenario to the "Configure inventory buffers and inventory levels" article, illustrating how an inventory buffer prevents overselling when the same product is sold simultaneously across multiple online channels.

The example walks through a concrete scenario (100 units of physical stock, concurrent orders across three channels) and shows how the buffer and inventory level profiles work together to catch oversell risk at the point of purchase.

Supersedes the first commit of #5185, which combined changes to two articles in a single PR. This PR contains only the change to this article, for easier review.