### PR TITLE
Fix solution name in BPA manual uninstallation steps

### DIFF
--- a/articles/finance/business-performance-analytics/uninstall-bpa.md
+++ b/articles/finance/business-performance-analytics/uninstall-bpa.md
@@ -326,7 +326,7 @@ Deleting all the solutions takes about 20 minutes. If the operation is successfu
 You can manually uninstall Business performance analytics through the Power Platform admin center. You must manually delete the solutions in the following order:
 
 1. Business performance analytics anchor solution
-1. Business performance analytics MCP
+1. ERP Analytics MCP server solution
 1. Business performance analytics solution
 1. Business performance analytics reports
 1. Business performance analytics plugins solution


### PR DESCRIPTION
Corrects the solution name in the manual uninstallation steps for Business performance analytics. Business performance analytics MCP did not match the actual solution name shown in Power Apps, causing customer confusion during uninstall. Updated to ERP Analytics MCP server solution.