### PR TITLE
Add note about unmanaged customizations requirement to BPA prerequisites

### DIFF
--- a/articles/finance/business-performance-analytics/configure-BPA.md
+++ b/articles/finance/business-performance-analytics/configure-BPA.md
@@ -73,7 +73,7 @@ Business performance analytics must be able to create unmanaged customizations i
 - Create solutions that allow the transport of custom reports from one organization to another.
 - Complete setup of the organization after installation.
 
-If the [Block unmanaged customizations](/power-platform/admin/settings-features#block-unmanaged-customizations) setting is turned on for the organization, see [Block unmanaged customizations](/power-platform/alm/block-unmanaged-customizations) for more information, since Business performance analytics might not work correctly.
+If the [Block unmanaged customizations](https://learn.microsoft.com/en-us/power-platform/admin/settings-features#block-unmanaged-customizations) setting is turned on for the organization, see [Block unmanaged customizations](https://learn.microsoft.com/en-us/power-platform/alm/block-unmanaged-customizations) for more information, since Business performance analytics might not work correctly.
 
 #### Configure Microsoft Power Platform
 

--- a/articles/finance/business-performance-analytics/configure-BPA.md
+++ b/articles/finance/business-performance-analytics/configure-BPA.md
@@ -40,6 +40,7 @@ Before installing Business performance analytics, complete the following prerequ
 - Configure Dynamics 365 Finance
 - Configure Power Platform Admin Center
 - Enable the Tabular Data Stream endpoint in Power Platform Admin Center
+- Allow unmanaged customizations in the environment
 
 #### Required privileges
 
@@ -63,6 +64,16 @@ Before installing Business performance analytics, complete the following prerequ
 - In Microsoft Dynamics Lifecycle Services:
 
   - The **Organization Admin** role to create environments. Additionally, the **Project owner** or **Environment manager** role must be assigned to the user in the **Project security** role field in Lifecycle Services.
+
+#### Allow unmanaged customizations
+
+Business performance analytics must be able to create unmanaged customizations in the environment where it's installed. This access allows Business performance analytics to (but isn't limited to):
+
+- Create custom reports.
+- Create solutions that allow the transport of custom reports from one organization to another.
+- Complete setup of the organization after installation.
+
+If the [Block unmanaged customizations](/power-platform/admin/settings-features#block-unmanaged-customizations) setting is turned on for the organization, see [Block unmanaged customizations](/power-platform/alm/block-unmanaged-customizations) for more information, since Business performance analytics might not work correctly.
 
 #### Configure Microsoft Power Platform
 

--- a/articles/finance/business-performance-analytics/configure-BPA.md
+++ b/articles/finance/business-performance-analytics/configure-BPA.md
@@ -41,6 +41,7 @@ Before installing Business performance analytics, complete the following prerequ
 - Configure Power Platform Admin Center
 - Enable the Tabular Data Stream endpoint in Power Platform Admin Center
 - Allow unmanaged customizations in the environment
+- Confirm the Finance and Operations virtual entities solution is installed
 
 #### Required privileges
 
@@ -84,6 +85,14 @@ To configure Microsoft Power Platform for Business performance analytics, follow
 3. Select **Full details** for the environment that you want to use for the setup.
 4. Confirm that the Microsoft Power Platform Integration is shown. If Microsoft Power Platform is set up, the name of the Microsoft Power Platform environment that's linked to the Dynamics 365 Finance environment is listed and shows a status of **Power Platform environment setup is complete**. If Microsoft Power Platform isn't set up, select **Setup**, and follow the prompts. After the setup is successfully completed, the name of the Microsoft Power Platform environment that's linked to the Dynamics 365 Finance environment is listed.
 5. If you set up the integration for an existing Microsoft Power Platform environment, confirm that the linked environment isn't in a disabled state. For more information, see [Enable Power Platform integration](../../fin-ops-core/dev-itpro/power-platform/enable-power-platform-integration.md). For more information, go to [Power Platform admin center](https://admin.powerplatform.microsoft.com/).
+
+#### Finance and Operations virtual entities solution
+
+Business performance analytics depends on the Finance and Operations virtual entities solution being installed in the Power Platform environment that's linked to your Dynamics 365 Finance environment. For more information, see [Getting the virtual entity solution](../../fin-ops-core/dev-itpro/power-platform/admin-reference.md#get-virtual-entity-solution).
+
+If you see an error message that resembles the following, the Finance and Operations virtual entities solution isn't installed:
+
+> Unable to establish connection using data source: 'Finance and Operations Virtual Data Source Configuration', Error: 'The entity with a name = 'mserp_financeandoperationsentity' with namemapping = 'Logical' was not found in the MetadataCache'
 
 #### Configure the Microsoft Entra tenant
 

--- a/articles/finance/business-performance-analytics/configure-BPA.md
+++ b/articles/finance/business-performance-analytics/configure-BPA.md
@@ -73,7 +73,7 @@ Business performance analytics must be able to create unmanaged customizations i
 - Create solutions that allow the transport of custom reports from one organization to another.
 - Complete setup of the organization after installation.
 
-If the [Block unmanaged customizations](https://learn.microsoft.com/en-us/power-platform/admin/settings-features#block-unmanaged-customizations) setting is turned on for the organization, see [Block unmanaged customizations](https://learn.microsoft.com/en-us/power-platform/alm/block-unmanaged-customizations) for more information, since Business performance analytics might not work correctly.
+If the setting "[Block unmanaged customizations](https://learn.microsoft.com/en-us/power-platform/admin/settings-features#block-unmanaged-customizations)" (full doc here [https://learn.microsoft.com/en-us/power-platform/alm/block-unmanaged-customizations](https://learn.microsoft.com/en-us/power-platform/alm/block-unmanaged-customizations)) is enabled on the organization, then Business performance analytics may not work correctly.
 
 #### Configure Microsoft Power Platform
 

--- a/articles/finance/business-performance-analytics/configure-BPA.md
+++ b/articles/finance/business-performance-analytics/configure-BPA.md
@@ -73,7 +73,7 @@ Business performance analytics must be able to create unmanaged customizations i
 - Create solutions that allow the transport of custom reports from one organization to another.
 - Complete setup of the organization after installation.
 
-If the setting "[Block unmanaged customizations](https://learn.microsoft.com/en-us/power-platform/admin/settings-features#block-unmanaged-customizations)" (full doc here [https://learn.microsoft.com/en-us/power-platform/alm/block-unmanaged-customizations](https://learn.microsoft.com/en-us/power-platform/alm/block-unmanaged-customizations)) is enabled on the organization, then Business performance analytics may not work correctly.
+If the [Block unmanaged customizations](https://learn.microsoft.com/en-us/power-platform/admin/settings-features#block-unmanaged-customizations) setting is enabled for the organization, Business performance analytics might not work correctly. For more information, see [Block unmanaged customizations in Dataverse environments](https://learn.microsoft.com/en-us/power-platform/alm/block-unmanaged-customizations).
 
 #### Configure Microsoft Power Platform
 

--- a/articles/finance/business-performance-analytics/current-challenges.md
+++ b/articles/finance/business-performance-analytics/current-challenges.md
@@ -93,3 +93,15 @@ This limit will be removed in the future.
 ### The size of the data lake folder increases every time Business performance analytics is refreshed
 
 Customers might notice that the size of the data lake folder increases each time that Business performance analytics refreshes its data. This issue occurs because stale folders are cleaned only every 30 days. In the future, stale folders are cleaned more often.
+
+### Administration controls aren't visible for a user in another language
+
+If a user with the Business performance analytics administrator role signs in to Reporting Hub and can't see the **Administration** controls, this can happen when the user's UI language isn't English (currently the only language that Business performance analytics supports). The Microsoft Dataverse sitemap that Business performance analytics uses isn't yet localized for other languages, so some controls don't appear.
+
+As a temporary workaround, switch to English (United States) in the following three places:
+
+1. **Environment language pack**: If English isn't already enabled for the environment, an administrator must add it before any user can select it. For more information, see [Enable languages in the Power Platform admin center](https://learn.microsoft.com/en-us/power-platform/admin/enable-languages).
+1. **Personal Dataverse language**: After English is enabled for the environment, update your personal language preference. For more information, see [Set personal options: Languages tab](https://learn.microsoft.com/en-us/power-apps/user/set-personal-options#languages-tab-options).
+1. **Browser language**: Set English (United States) as the top preferred language in your browser, since the browser's preferred language also affects how Business performance analytics renders.
+
+This is a temporary workaround until Business performance analytics is localized for additional languages.


### PR DESCRIPTION
Adds guidance that Business performance analytics needs the ability to create unmanaged customizations in the environment where it's installed (used for custom reports, transporting custom reports between organizations, and completing org setup after installation), and links to the "Block unmanaged customizations" setting/doc so customers know why BPA may not work correctly if that setting is enabled.

Fixes AB#6646228