### PR TITLE
Update iOS support status in retail peripherals overview

### DIFF
--- a/articles/commerce/retail-peripherals-overview.md
+++ b/articles/commerce/retail-peripherals-overview.md
@@ -269,7 +269,7 @@ The IPC hardware station supports network peripherals directly through the hardw
 | Windows app | Yes                  | Yes                  |
 | Cloud POS   | No                   | Yes                  |
 | Android     | Yes                  | Yes                  |
-| iOS         | No                   | Yes                  |
+| iOS         | Yes                   | Yes                  |
 
 ## Supported device types by hardware station type
 ### Modern POS for Windows with an IPC (built-in) hardware station


### PR DESCRIPTION
Store Commerce for iOS supports Network peripherals via IPC HW station.